### PR TITLE
Postcode as a start route

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -10,6 +10,10 @@ export interface RecyclingLocatorAttributes {
    */
   readonly locale?: Locale;
   /**
+   * Prefill the postcode to skip the start view
+   */
+  readonly postcode?: string;
+  /**
    * How to render
    * - Widget will render as an embed within a page
    * - Standalone will render as a full page and change the browser history upon navigation
@@ -29,6 +33,7 @@ export interface RecyclingLocatorAttributes {
  */
 export default function RecyclingLocator({
   locale,
+  postcode,
   variant = 'widget',
   basename = '/',
 }: RecyclingLocatorAttributes) {
@@ -36,7 +41,12 @@ export default function RecyclingLocator({
     <>
       <link rel="stylesheet" href="/styles.css" />
       <article className={`recycling-locator-variant-${variant}`}>
-        <Entrypoint locale={locale} variant={variant} basename={basename} />
+        <Entrypoint
+          locale={locale}
+          postcode={postcode}
+          variant={variant}
+          basename={basename}
+        />
       </article>
     </>
   );
@@ -45,7 +55,7 @@ export default function RecyclingLocator({
 register(
   RecyclingLocator,
   'recycling-locator',
-  ['locale', 'variant', 'basename'],
+  ['locale', 'postcode', 'variant', 'basename'],
   {
     shadow: true,
   },

--- a/src/lib/AppState.tsx
+++ b/src/lib/AppState.tsx
@@ -1,0 +1,26 @@
+import { createContext } from 'preact';
+import { useContext } from 'preact/hooks';
+
+import { RecyclingLocatorAttributes } from '..';
+
+interface AppStateContext extends RecyclingLocatorAttributes {
+  startRoute: string;
+}
+
+export const AppState = createContext<AppStateContext>(null);
+
+export function createAppState(
+  attributes: RecyclingLocatorAttributes,
+): AppStateContext {
+  const { postcode } = attributes;
+  const startRoute = postcode ? `/${postcode}` : '/';
+
+  return {
+    ...attributes,
+    startRoute,
+  };
+}
+
+export function useAppState() {
+  return useContext(AppState);
+}

--- a/src/pages/entrypoint.tsx
+++ b/src/pages/entrypoint.tsx
@@ -8,6 +8,7 @@ import {
 
 import '@/lib/sentry';
 import { RecyclingLocatorAttributes } from '@/index';
+import { AppState, createAppState } from '@/lib/AppState';
 import { i18nInit } from '@/lib/i18n';
 
 import postcodeRoutes from './[postcode]/postcode.routes';
@@ -39,11 +40,11 @@ const routes: RouteObject[] = [
  * - Init i18n (using suspense to wait for them to load in)
  * - Init Sentry
  */
-export default function Entrypoint({
-  locale,
-  variant,
-  basename,
-}: Readonly<RecyclingLocatorAttributes>) {
+export default function Entrypoint(
+  props: Readonly<RecyclingLocatorAttributes>,
+) {
+  const { locale, variant, basename } = props;
+
   i18nInit(locale);
 
   const router =
@@ -53,7 +54,9 @@ export default function Entrypoint({
 
   return (
     <Suspense fallback={<h2>loading...</h2>}>
-      <RouterProvider router={router} />
+      <AppState.Provider value={createAppState(props)}>
+        <RouterProvider router={router} />
+      </AppState.Provider>
     </Suspense>
   );
 }

--- a/src/pages/start.page.tsx
+++ b/src/pages/start.page.tsx
@@ -1,17 +1,34 @@
 import { useSignal } from '@preact/signals';
+import { useEffect } from 'preact/hooks';
 import { useTranslation } from 'react-i18next';
-import { Form } from 'react-router-dom';
+import { Form, useNavigate } from 'react-router-dom';
 import '@etchteam/diamond-ui/composition/FormGroup/FormGroup';
 import '@etchteam/diamond-ui/control/Button/Button';
 import '@etchteam/diamond-ui/canvas/Section/Section';
 
 import '@/components/composition/Wrap/Wrap';
 import '@/components/control/LocationInput/LocationInput';
+import { useAppState } from '@/lib/AppState';
 import StartLayout from '@/pages/layout';
 
 export default function StartPage() {
   const { t } = useTranslation();
+  const navigateTo = useNavigate();
+  const { startRoute } = useAppState();
   const submitting = useSignal(false);
+  const finishedLoading = useSignal(false);
+
+  useEffect(() => {
+    if (!finishedLoading.value && startRoute !== '/') {
+      navigateTo(startRoute);
+    } else {
+      finishedLoading.value = true;
+    }
+  }, [startRoute]);
+
+  if (finishedLoading.value !== true) {
+    return null;
+  }
 
   return (
     <StartLayout>


### PR DESCRIPTION
- Adds a postcode prop to the web component to allow people to skip location entry
- Wraps the app in a global app state provider, will probably use this for more stuff later
- We need to handle navigation inside the start route because that's where routeProvider will be available