### PR TITLE
About info button accessibility

### DIFF
--- a/public/translations/cy.json
+++ b/public/translations/cy.json
@@ -28,6 +28,10 @@
     }
   },
   "about": {
+    "button": {
+      "view": "Gweld gwybodaeth",
+      "close": "Gwybodaeth clos"
+    },
     "title": "Am y gwasanaeth hwn",
     "intro": "Wedi'i bweru gan RecycleNow.com, gellir defnyddio'r offeryn hwn i chwilio a dod o hyd i leoliadau ailgylchu ledled y Deyrnas Unedig.",
     "becomeAPartner": {

--- a/public/translations/en.json
+++ b/public/translations/en.json
@@ -28,6 +28,10 @@
     }
   },
   "about": {
+    "button": {
+      "view": "View information",
+      "close": "Close information"
+    },
     "title": "About this service",
     "intro": "Powered by RecycleNow.com, this tool can be used to search and find recycling locations throughout the United Kingdom.",
     "becomeAPartner": {

--- a/src/components/content/Icon/Icon.tsx
+++ b/src/components/content/Icon/Icon.tsx
@@ -29,7 +29,7 @@ export default function Icon({ icon, label }: IconAttributes) {
   );
 }
 
-register(Icon, 'locator-icon', ['icon']);
+register(Icon, 'locator-icon', ['icon', 'label']);
 
 declare module 'react' {
   namespace JSX {

--- a/src/pages/start.layout.tsx
+++ b/src/pages/start.layout.tsx
@@ -2,6 +2,7 @@ import { useSignal } from '@preact/signals';
 import { ComponentChildren } from 'preact';
 import { useTranslation } from 'react-i18next';
 import '@etchteam/diamond-ui/control/Button/Button';
+import '@etchteam/diamond-ui/canvas/Section/Section';
 
 import '@/components/composition/Layout/Layout';
 import '@/components/composition/Header/Header';
@@ -9,8 +10,6 @@ import '@/components/content/Logo/Logo';
 import '@/components/content/Icon/Icon';
 import '@/components/canvas/Tip/Tip';
 import '@/components/composition/Wrap/Wrap';
-
-import '@etchteam/diamond-ui/canvas/Section/Section';
 
 function About() {
   const { t } = useTranslation();
@@ -84,16 +83,21 @@ export default function StartLayout({
           <button
             type="button"
             data-testid="about-button"
+            aria-expanded={open.value}
+            aria-controls="locator-layout-main"
             onClick={() => (open.value = !open.value)}
           >
             <locator-icon
               icon={open.value ? 'close' : 'info'}
+              label={open.value ? 'Close information' : 'View information'}
               color="primary"
             ></locator-icon>
           </button>
         </diamond-button>
       </locator-header>
-      <div slot="main">{open.value ? <About /> : children}</div>
+      <div slot="main" id="locator-layout-main">
+        {open.value ? <About /> : children}
+      </div>
       <div slot="aside" className="display-contents">
         {aside ?? <DefaultAside />}
       </div>

--- a/src/pages/start.layout.tsx
+++ b/src/pages/start.layout.tsx
@@ -73,6 +73,7 @@ export default function StartLayout({
   readonly children: ComponentChildren;
   readonly aside?: ComponentChildren;
 }) {
+  const { t } = useTranslation();
   const open = useSignal(false);
 
   return (
@@ -89,7 +90,7 @@ export default function StartLayout({
           >
             <locator-icon
               icon={open.value ? 'close' : 'info'}
-              label={open.value ? 'Close information' : 'View information'}
+              label={t(`about.button.${open.value ? 'close' : 'view'}`)}
               color="primary"
             ></locator-icon>
           </button>


### PR DESCRIPTION
Makes the about info button appear to screen readers as a thing that expands/collapses content which is closest to what it's actually doing visually and indicates what content it's controlling.

Fixes the button not containing any label text.