### PR TITLE
Material search header

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,6 +45,10 @@
             <li>
               <a href="/notapostcode">Postcode not found</a>
             </li>
+            <li>
+              <a href="/EX327RB/material">Material</a>
+            </li>
+
           </ul>
         </nav>
 

--- a/public/translations/cy.json
+++ b/public/translations/cy.json
@@ -1,10 +1,13 @@
 {
+  "actions": {
+    "back": "Yn ol",
+    "search": "Chwiliwch"
+  },
   "components": {
     "locationInput": {
       "placeholder": "Rhowch dref neu god post..."
     },
     "materialSearchInput": {
-      "buttonLabel": "Chwiliwch",
       "placeholder": "Rhowch enw eitem..."
     }
   },
@@ -68,5 +71,8 @@
       "home": "Casgliad ailgylchu cartref",
       "nearest": "Lleoedd agosaf i ailgylchu"
     }
+  },
+  "material": {
+    "title": "Ailgylchu eitem benodol"
   }
 }

--- a/public/translations/en.json
+++ b/public/translations/en.json
@@ -1,10 +1,13 @@
 {
+  "actions": {
+    "back": "Back",
+    "search": "Search"
+  },
   "components": {
     "locationInput": {
       "placeholder": "Enter a town or postcode..."
     },
     "materialSearchInput": {
-      "buttonLabel": "Search",
       "placeholder": "Enter the name of an item..."
     }
   },
@@ -68,5 +71,8 @@
       "home": "Home recycling collection",
       "nearest": "Nearest places to recycle"
     }
+  },
+  "material": {
+    "title": "Recycle a specific item"
   }
 }

--- a/src/components/canvas/ContextHeader/ContextHeader.stories.tsx
+++ b/src/components/canvas/ContextHeader/ContextHeader.stories.tsx
@@ -3,7 +3,7 @@ import { Meta, StoryObj } from '@storybook/preact';
 import './ContextHeader';
 
 const meta: Meta = {
-  title: 'Components/ContextHeader',
+  title: 'Components/Canvas/ContextHeader',
 };
 
 export default meta;

--- a/src/components/canvas/MapSvg/MapSvg.stories.tsx
+++ b/src/components/canvas/MapSvg/MapSvg.stories.tsx
@@ -3,7 +3,7 @@ import { Meta, StoryObj } from '@storybook/preact';
 import './MapSvg';
 
 const meta: Meta = {
-  title: 'Components/MapSvg',
+  title: 'Components/Canvas/MapSvg',
 };
 
 export default meta;

--- a/src/components/canvas/Tip/Tip.stories.tsx
+++ b/src/components/canvas/Tip/Tip.stories.tsx
@@ -3,7 +3,7 @@ import { Meta, StoryObj } from '@storybook/preact';
 import './Tip';
 
 const meta: Meta = {
-  title: 'Components/Tip',
+  title: 'Components/Canvas/Tip',
 };
 
 export default meta;

--- a/src/components/composition/BorderedList/BorderedList.stories.tsx
+++ b/src/components/composition/BorderedList/BorderedList.stories.tsx
@@ -3,7 +3,7 @@ import { Meta, StoryObj } from '@storybook/preact';
 import './BorderedList';
 
 const meta: Meta = {
-  title: 'Components/BorderedList',
+  title: 'Components/Composition/BorderedList',
 };
 
 export default meta;

--- a/src/components/composition/Header/Header.stories.tsx
+++ b/src/components/composition/Header/Header.stories.tsx
@@ -3,7 +3,7 @@ import { Meta, StoryObj } from '@storybook/preact';
 import './Header';
 
 const meta: Meta = {
-  title: 'Components/Header',
+  title: 'Components/Composition/Header',
 };
 
 export default meta;

--- a/src/components/composition/Wrap/Wrap.stories.tsx
+++ b/src/components/composition/Wrap/Wrap.stories.tsx
@@ -3,7 +3,7 @@ import { Meta, StoryObj } from '@storybook/preact';
 import './Wrap';
 
 const meta: Meta = {
-  title: 'Components/Wrap',
+  title: 'Components/Composition/Wrap',
 };
 
 export default meta;

--- a/src/components/content/HeaderTitle/HeaderTitle.css
+++ b/src/components/content/HeaderTitle/HeaderTitle.css
@@ -1,0 +1,32 @@
+locator-header-title {
+  align-items: center;
+  display: grid;
+  gap: var(--diamond-spacing-sm);
+  grid-template-areas: 'button title';
+  grid-template-columns: auto 1fr;
+
+  > * {
+    grid-area: title;
+  }
+
+  diamond-button {
+    grid-area: button;
+    --diamond-button-border-radius: 50%;
+    --diamond-button-padding-block: var(--diamond-spacing-sm);
+    --diamond-button-padding-inline: var(--diamond-spacing-sm);
+  }
+
+  h2,
+  p {
+    margin-block-end: 0;
+  }
+
+  h2 {
+    font-size: var(--diamond-font-size-lg);
+    font-weight: var(--diamond-font-weight-bold);
+  }
+
+  p {
+    font-size: var(--diamond-font-size-sm);
+  }
+}

--- a/src/components/content/HeaderTitle/HeaderTitle.stories.tsx
+++ b/src/components/content/HeaderTitle/HeaderTitle.stories.tsx
@@ -1,0 +1,27 @@
+import { Meta, StoryObj } from '@storybook/preact';
+import '@etchteam/diamond-ui/control/Button/Button';
+
+import '@/components/content/Icon/Icon';
+import './HeaderTitle';
+
+const meta: Meta = {
+  title: 'Components/Content/HeaderTitle',
+};
+
+export default meta;
+
+export const HeaderTitle: StoryObj = {
+  render: () => (
+    <locator-header-title>
+      <diamond-button>
+        <a href="#link">
+          <locator-icon icon="arrow-left" label="Back"></locator-icon>
+        </a>
+      </diamond-button>
+      <div>
+        <h2>Recycle a specific item</h2>
+        <p>EX327RB</p>
+      </div>
+    </locator-header-title>
+  ),
+};

--- a/src/components/content/HeaderTitle/HeaderTitle.tsx
+++ b/src/components/content/HeaderTitle/HeaderTitle.tsx
@@ -1,0 +1,9 @@
+import { CustomElement } from '@/types/customElement';
+
+declare module 'react' {
+  namespace JSX {
+    interface IntrinsicElements {
+      'locator-header-title': CustomElement;
+    }
+  }
+}

--- a/src/components/content/Icon/Icon.tsx
+++ b/src/components/content/Icon/Icon.tsx
@@ -14,7 +14,8 @@ export interface IconAttributes {
     | 'home'
     | 'distance'
     | 'search'
-    | 'map';
+    | 'map'
+    | 'arrow-left';
   readonly color?: 'primary';
   readonly label?: string;
 }

--- a/src/components/content/Icon/svg/arrow-left.svg
+++ b/src/components/content/Icon/svg/arrow-left.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M7.825 13L13.425 18.6L12 20L4 12L12 4L13.425 5.4L7.825 11H20V13H7.825Z" fill="black"/>
+</svg>

--- a/src/components/control/IconLink/IconLink.stories.tsx
+++ b/src/components/control/IconLink/IconLink.stories.tsx
@@ -4,7 +4,7 @@ import '@/components/content/Icon/Icon';
 import './IconLink';
 
 const meta: Meta = {
-  title: 'Components/IconLink',
+  title: 'Components/Control/IconLink',
 };
 
 export default meta;

--- a/src/components/control/MaterialSearchInput/MaterialSearchInput.tsx
+++ b/src/components/control/MaterialSearchInput/MaterialSearchInput.tsx
@@ -73,7 +73,7 @@ export default class MaterialSearchInput extends Component<MaterialSearchInputPr
           <button type="submit" disabled={submitting && submitting !== 'false'}>
             <locator-icon
               icon="search"
-              label={i18n.t('components.materialSearchInput.buttonLabel')}
+              label={i18n.t('actions.search')}
             ></locator-icon>
           </button>
         </diamond-button>

--- a/src/pages/[postcode]/material/material.layout.tsx
+++ b/src/pages/[postcode]/material/material.layout.tsx
@@ -1,0 +1,38 @@
+import { Outlet, useParams } from 'react-router-dom';
+import '@etchteam/diamond-ui/control/Button/Button';
+import '@etchteam/diamond-ui/canvas/Section/Section';
+
+import '@/components/composition/Layout/Layout';
+import '@/components/composition/Header/Header';
+import '@/components/canvas/Tip/Tip';
+import '@/components/composition/Wrap/Wrap';
+
+export default function MaterialLayout() {
+  const { postcode } = useParams();
+
+  return (
+    <locator-layout>
+      <locator-header slot="header">
+        <h2>Recycle a specific item</h2>
+        <p>{postcode}</p>
+      </locator-header>
+      <div slot="main">
+        <Outlet />
+      </div>
+      <locator-tip slot="aside" text-align="center">
+        <locator-wrap>
+          <img src="/images/recycling-technology.webp" alt="" />
+          <p className="text-weight-bold">Hints and tips</p>
+          <h2>How to check if your electricals can be recycled</h2>
+          <p>
+            Any items that have a plug, use batteries, need charging or have a
+            picture of a crossed out wheelie bin on, are known as Waste
+            Electrical and Electronic Equipment (WEEE). These items should not
+            be sent to landfill and should be recycled at Recycling Centres,
+            electrical item bring banks or via electrical retailers
+          </p>
+        </locator-wrap>
+      </locator-tip>
+    </locator-layout>
+  );
+}

--- a/src/pages/[postcode]/material/material.layout.tsx
+++ b/src/pages/[postcode]/material/material.layout.tsx
@@ -1,4 +1,4 @@
-import { Outlet, useParams } from 'react-router-dom';
+import { Link, Outlet, useParams } from 'react-router-dom';
 import '@etchteam/diamond-ui/control/Button/Button';
 import '@etchteam/diamond-ui/canvas/Section/Section';
 
@@ -6,6 +6,7 @@ import '@/components/composition/Layout/Layout';
 import '@/components/composition/Header/Header';
 import '@/components/canvas/Tip/Tip';
 import '@/components/composition/Wrap/Wrap';
+import '@/components/content/HeaderTitle/HeaderTitle';
 
 export default function MaterialLayout() {
   const { postcode } = useParams();
@@ -13,8 +14,17 @@ export default function MaterialLayout() {
   return (
     <locator-layout>
       <locator-header slot="header">
-        <h2>Recycle a specific item</h2>
-        <p>{postcode}</p>
+        <locator-header-title>
+          <diamond-button>
+            <Link to={`/${postcode}`}>
+              <locator-icon icon="arrow-left" label="Back"></locator-icon>
+            </Link>
+          </diamond-button>
+          <div>
+            <h2>Recycle a specific item</h2>
+            <p>{postcode}</p>
+          </div>
+        </locator-header-title>
       </locator-header>
       <div slot="main">
         <Outlet />

--- a/src/pages/[postcode]/material/material.page.tsx
+++ b/src/pages/[postcode]/material/material.page.tsx
@@ -1,0 +1,3 @@
+export default function MaterialPage() {
+  return <h2>Yes, it can be recycled!</h2>;
+}

--- a/src/pages/[postcode]/material/material.routes.tsx
+++ b/src/pages/[postcode]/material/material.routes.tsx
@@ -1,0 +1,14 @@
+import { RouteObject } from 'react-router-dom';
+
+import MaterialLayout from './material.layout';
+import MaterialPage from './material.page';
+
+const routes: RouteObject[] = [
+  {
+    path: '/:postcode/material',
+    element: <MaterialLayout />,
+    children: [{ index: true, element: <MaterialPage /> }],
+  },
+];
+
+export default routes;

--- a/src/pages/[postcode]/postcode.routes.tsx
+++ b/src/pages/[postcode]/postcode.routes.tsx
@@ -2,6 +2,7 @@ import { RouteObject } from 'react-router-dom';
 
 import NotFoundPage from '@/pages/not-found.page';
 
+import materialRoutes from './material/material.routes';
 import postcodeAction from './postcode.action';
 import postcodeLoader from './postcode.loader';
 import PostcodePage from './postcode.page';
@@ -15,6 +16,7 @@ const routes: RouteObject[] = [
     loader: postcodeLoader,
     errorElement: <NotFoundPage />,
   },
+  ...materialRoutes,
 ];
 
 export default routes;

--- a/src/pages/root.layout.tsx
+++ b/src/pages/root.layout.tsx
@@ -17,6 +17,7 @@ export default function RootLayout() {
 
   useEffect(() => {
     if (loadedStartPath.value !== startPath && startPath !== currentPath) {
+      console.log('navigating to start path', startPath);
       navigateTo(startPath);
     }
 

--- a/src/pages/root.layout.tsx
+++ b/src/pages/root.layout.tsx
@@ -17,7 +17,6 @@ export default function RootLayout() {
 
   useEffect(() => {
     if (loadedStartPath.value !== startPath && startPath !== currentPath) {
-      console.log('navigating to start path', startPath);
       navigateTo(startPath);
     }
 


### PR DESCRIPTION
- Sets up the /material route for the material search result page
- Adds a new header style in the material layout
- Moves global actions to a new translation section so they aren't repeated everywhere
- Scopes all stories under the diamond structure