### PR TITLE
Material not found view

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,6 +48,9 @@
             <li>
               <a href="/EX327RB/material?id=43&name=Plastic%20milk%20bottles">Material</a>
             </li>
+            <li>
+              <a href="/EX327RB/material/not-found?name=Not%20a%20material">Material not found</a>
+            </li>
           </ul>
         </nav>
 

--- a/public/translations/cy.json
+++ b/public/translations/cy.json
@@ -73,6 +73,11 @@
     }
   },
   "material": {
-    "title": "Ailgylchu eitem benodol"
+    "title": "Ailgylchu eitem benodol",
+    "notFound": {
+      "title": "Ni allem ddod o hyd i gyfatebiaeth ar gyfer",
+      "label": "Chwiliwch eto",
+      "help": "Ceisiwch ddefnyddio enw arall ar ei gyfer, neu chwiliwch am eitem neu ddeunydd tebyg."
+    }
   }
 }

--- a/public/translations/en.json
+++ b/public/translations/en.json
@@ -73,6 +73,11 @@
     }
   },
   "material": {
-    "title": "Recycle a specific item"
+    "title": "Recycle a specific item",
+    "notFound": {
+      "title": "We couldn’t find a match for",
+      "label": "Search again",
+      "help": "Try using an alternative name for it, or search for a similar item or material."
+    }
   }
 }

--- a/src/pages/[postcode]/material/material.layout.tsx
+++ b/src/pages/[postcode]/material/material.layout.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import { Link, Outlet, useParams, useSearchParams } from 'react-router-dom';
 import '@etchteam/diamond-ui/control/Button/Button';
 import '@etchteam/diamond-ui/canvas/Section/Section';
@@ -13,6 +14,7 @@ import '@/components/content/HeaderTitle/HeaderTitle';
 import '@/components/content/Icon/Icon';
 
 export default function MaterialLayout() {
+  const { t } = useTranslation();
   const { postcode } = useParams();
   const [searchParams] = useSearchParams();
   const materialId = searchParams.get('id');
@@ -28,7 +30,7 @@ export default function MaterialLayout() {
             </Link>
           </diamond-button>
           <div>
-            <h2>Recycle a specific item</h2>
+            <h2>{t('material.title')}</h2>
             <p>{postcode}</p>
           </div>
         </locator-header-title>

--- a/src/pages/[postcode]/material/material.routes.tsx
+++ b/src/pages/[postcode]/material/material.routes.tsx
@@ -1,13 +1,19 @@
 import { RouteObject } from 'react-router-dom';
 
+import postcodeAction from '../postcode.action';
+
 import MaterialLayout from './material.layout';
 import MaterialPage from './material.page';
+import NotFoundPage from './not-found.page';
 
 const routes: RouteObject[] = [
   {
     path: '/:postcode/material',
     element: <MaterialLayout />,
-    children: [{ index: true, element: <MaterialPage /> }],
+    children: [
+      { index: true, element: <MaterialPage /> },
+      { path: 'not-found', element: <NotFoundPage />, action: postcodeAction },
+    ],
   },
 ];
 

--- a/src/pages/[postcode]/material/not-found.page.tsx
+++ b/src/pages/[postcode]/material/not-found.page.tsx
@@ -1,0 +1,45 @@
+import { useSignal } from '@preact/signals';
+import { useEffect } from 'preact/hooks';
+import { useTranslation } from 'react-i18next';
+import { Form, useSearchParams } from 'react-router-dom';
+import '@etchteam/diamond-ui/canvas/Section/Section';
+import '@etchteam/diamond-ui/composition/FormGroup/FormGroup';
+
+import '@/components/composition/Wrap/Wrap';
+import '@/components/control/MaterialSearchInput/MaterialSearchInput';
+
+export default function NotFoundPage() {
+  const { t } = useTranslation();
+  const [searchParams] = useSearchParams();
+  const materialName = searchParams.get('name');
+  const submitting = useSignal(false);
+
+  useEffect(() => {
+    submitting.value = false;
+  }, [materialName]);
+
+  return (
+    <locator-wrap>
+      <diamond-section padding="lg">
+        <h3>
+          {t('material.notFound.title')}{' '}
+          <span className="text-weight-bold">
+            {materialName.toLocaleLowerCase()}
+          </span>
+        </h3>
+        <Form method="post" onSubmit={() => (submitting.value = true)}>
+          <diamond-form-group>
+            <label htmlFor="locator-material-input">
+              {t('material.notFound.label')}
+            </label>
+            <locator-material-search-input
+              placeholder={t('components.materialSearchInput.placeholder')}
+              submitting={submitting.value}
+            ></locator-material-search-input>
+            <p className="text-size-sm">{t('material.notFound.help')}</p>
+          </diamond-form-group>
+        </Form>
+      </diamond-section>
+    </locator-wrap>
+  );
+}

--- a/src/pages/[postcode]/postcode.action.ts
+++ b/src/pages/[postcode]/postcode.action.ts
@@ -20,5 +20,6 @@ export default async function postcodeAction({
     return redirect(`/${postcode}/material?id=${id}&name=${safeName}`);
   }
 
-  return redirect(`/${postcode}/material/not-found`);
+  const safeSearchTerm = encodeURIComponent(formData.get('search') as string);
+  return redirect(`/${postcode}/material/not-found?name=${safeSearchTerm}`);
 }

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -11,6 +11,10 @@
   font-size: var(--diamond-font-size-h3);
 }
 
+.text-size-sm {
+  font-size: var(--diamond-font-size-sm);
+}
+
 .text-decoration-none {
   text-decoration: none;
 }


### PR DESCRIPTION
Adds the material not found view.

Eventually, popular searches should also be part of this view – I'll add them in a separate PR.

It's a bit weird that this view uses the postcode form action but this view is firmly a material layout view instead of the start layout view because the user has committed to searching for a material, I could rename the postcode action but then it breaks convention, I could create a not-found.action that uses the postcode.action but that just adds code and ends up in the same place, I've left it for now and will see if any other routes break the convention if so the convention might need to change.