### PR TITLE
Material result error boundary

### DIFF
--- a/public/translations/cy.json
+++ b/public/translations/cy.json
@@ -4,7 +4,8 @@
   },
   "actions": {
     "back": "Yn ol",
-    "search": "Chwiliwch"
+    "search": "Chwiliwch",
+    "searchAgain": "Chwiliwch eto"
   },
   "components": {
     "locationInput": {
@@ -129,8 +130,7 @@
     "nearbyPlaces": {
       "noPlaces": {
         "title": "Nid oes unrhyw leoedd cyfagos i ailgylchu'r eitem hon.",
-        "content": "Dim lleoedd o fewn 25 milltir i {{ postcode }}",
-        "cta": "Chwiliwch eto"
+        "content": "Dim lleoedd o fewn 25 milltir i {{ postcode }}"
       },
       "places": {
         "title": "Ailgylchu mewn man cyfagos",
@@ -143,9 +143,11 @@
     },
     "search": {
       "notFound": "Ni allem ddod o hyd i gyfatebiaeth ar gyfer",
-      "label": "Chwiliwch eto",
       "help": "Ceisiwch ddefnyddio enw arall ar ei gyfer, neu chwiliwch am eitem neu ddeunydd tebyg.",
       "popular": "Chwiliadau poblogaidd"
+    },
+    "error": {
+      "message": "Digwyddodd gwall annisgwyl wrth chwilio am leoedd i ailgylchu'r eitem hon."
     }
   }
 }

--- a/public/translations/en.json
+++ b/public/translations/en.json
@@ -4,7 +4,8 @@
   },
   "actions": {
     "back": "Back",
-    "search": "Search"
+    "search": "Search",
+    "searchAgain": "Search again"
   },
   "components": {
     "locationInput": {
@@ -129,8 +130,7 @@
     "nearbyPlaces": {
       "noPlaces": {
         "title": "There are no nearby places to recycle this item.",
-        "content": "No places within 25 miles of {{ postcode }}",
-        "cta": "Search again"
+        "content": "No places within 25 miles of {{ postcode }}"
       },
       "places": {
         "title": "Recycle at a nearby place",
@@ -143,9 +143,11 @@
     },
     "search": {
       "notFound": "We couldn’t find a match for",
-      "label": "Search again",
       "help": "Try using an alternative name for it, or search for a similar item or material.",
       "popular": "Popular searches"
+    },
+    "error": {
+      "message": "An unexpected error occurred whilst searching for places to recycle this item."
     }
   }
 }

--- a/src/pages/[postcode]/material/NearbyPlaces.tsx
+++ b/src/pages/[postcode]/material/NearbyPlaces.tsx
@@ -29,7 +29,9 @@ function NoPlaces() {
         {t(`${tContext}.content`, { postcode })}
       </p>
       <diamond-button width="full-width">
-        <Link to={`/${postcode}/material/search`}>{t(`${tContext}.cta`)}</Link>
+        <Link to={`/${postcode}/material/search`}>
+          {t('actions.searchAgain')}
+        </Link>
       </diamond-button>
     </diamond-card>
   );

--- a/src/pages/[postcode]/material/error.page.tsx
+++ b/src/pages/[postcode]/material/error.page.tsx
@@ -1,0 +1,31 @@
+import * as Sentry from '@sentry/browser';
+import { useTranslation } from 'react-i18next';
+import { Link, useParams, useRouteError } from 'react-router-dom';
+import '@etchteam/diamond-ui/control/Button/Button';
+import '@etchteam/diamond-ui/canvas/Section/Section';
+
+import '@/components/composition/Wrap/Wrap';
+
+export default function MaterialErrorPage() {
+  const { t } = useTranslation();
+  const { postcode } = useParams();
+  const error = useRouteError();
+  Sentry.captureException(error, {
+    tags: { route: 'Material result error boundary' },
+  });
+
+  return (
+    <locator-wrap>
+      <diamond-section padding="lg">
+        <h2>{t('error.title')}</h2>
+        <p>{t('material.error.message')}</p>
+        <p className="diamond-spacing-bottom-md">{t('error.message')}</p>
+        <diamond-button width="full-width" variant="primary">
+          <Link to={`/${postcode}/material/search`}>
+            {t('actions.searchAgain')}
+          </Link>
+        </diamond-button>
+      </diamond-section>
+    </locator-wrap>
+  );
+}

--- a/src/pages/[postcode]/material/material.routes.tsx
+++ b/src/pages/[postcode]/material/material.routes.tsx
@@ -2,6 +2,7 @@ import { RouteObject } from 'react-router-dom';
 
 import postcodeAction from '../postcode.action';
 
+import MaterialErrorPage from './error.page';
 import MaterialLayout from './material.layout';
 import materialLoader from './material.loader';
 import MaterialPage from './material.page';
@@ -13,12 +14,18 @@ const routes: RouteObject[] = [
     path: '/:postcode/material',
     element: <MaterialLayout />,
     children: [
-      { index: true, element: <MaterialPage />, loader: materialLoader },
+      {
+        index: true,
+        element: <MaterialPage />,
+        loader: materialLoader,
+        errorElement: <MaterialErrorPage />,
+      },
       {
         path: 'search',
         element: <MaterialSearchPage />,
         action: postcodeAction,
         loader: materialSearchLoader,
+        errorElement: <MaterialErrorPage />,
       },
     ],
   },

--- a/src/pages/[postcode]/material/search.loader.ts
+++ b/src/pages/[postcode]/material/search.loader.ts
@@ -9,18 +9,14 @@ export interface MaterialSearchLoaderResponse {
 }
 
 async function getData(): Promise<MaterialSearchLoaderResponse> {
-  const popularMaterials = await LocatorApi.get<Material[]>(
-    'materials?popular=true',
-  );
-
-  return {
-    popularMaterials,
-  };
-}
-
-export default function materialSearchLoader() {
   try {
-    return defer({ data: getData() });
+    const popularMaterials = await LocatorApi.get<Material[]>(
+      'materials?popular=true',
+    );
+
+    return {
+      popularMaterials,
+    };
   } catch (error) {
     Sentry.captureException(error, {
       tags: { route: 'Material search loader' },
@@ -28,4 +24,8 @@ export default function materialSearchLoader() {
     // Let the user carry on without the popularMaterials
     return Promise.resolve({ popularMaterials: [] });
   }
+}
+
+export default function materialSearchLoader() {
+  return defer({ data: getData() });
 }

--- a/src/pages/[postcode]/material/search.page.tsx
+++ b/src/pages/[postcode]/material/search.page.tsx
@@ -78,7 +78,7 @@ export default function MaterialSearchPage() {
         <Form method="post" onSubmit={() => (submitting.value = true)}>
           <diamond-form-group>
             <label htmlFor="locator-material-input">
-              {t('material.search.label')}
+              {t('actions.searchAgain')}
             </label>
             <locator-material-search-input
               placeholder={t('components.materialSearchInput.placeholder')}


### PR DESCRIPTION
Creates a material result-specific error boundary to avoid resorting to the global error boundary which would make users start again from the location search.

Other updates:

- Fixes the popular searches error handling, I think the react-router `defer` caused the catch block to be ignored
- Moves "search again" to a generic action translation because we have it three times now