### PR TITLE
Home recycling error handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,6 +79,11 @@
             </li>
             <li>
               <a href="/EX327RB/home">Home recycling</a>
+              <ul>
+                <li>
+                  <a href="/NOTAPOSTCODE/home">LA not found</a>
+                </li>
+              </ul>
             </li>
           </ul>
         </nav>

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "storybook:build": "storybook build",
     "test": "vitest --ui",
     "test:ci": "vitest",
-    "test:debug": "PWDEBUG=console vitest --ui"
+    "test:debug": "DEBUG=pw:api PWDEBUG=console vitest --ui"
   },
   "dependencies": {
     "@etchteam/diamond-ui": "^1.25.2",

--- a/public/translations/cy.json
+++ b/public/translations/cy.json
@@ -8,7 +8,7 @@
     "back": "Yn ol",
     "search": "Chwiliwch",
     "searchAgain": "Chwiliwch eto",
-    "tryAgain": "Try again",
+    "tryAgain": "Ceisio eto",
     "listPlaces": "Rhestru lleoedd",
     "showMap": "Dangos map"
   },

--- a/public/translations/cy.json
+++ b/public/translations/cy.json
@@ -8,6 +8,7 @@
     "back": "Yn ol",
     "search": "Chwiliwch",
     "searchAgain": "Chwiliwch eto",
+    "tryAgain": "Try again",
     "listPlaces": "Rhestru lleoedd",
     "showMap": "Dangos map"
   },
@@ -201,6 +202,9 @@
         ],
         "paragraphTwo": "Byddant hefyd yn gallu dweud wrthych pryd mae pob casgliad wedi'i amserlennu."
       }
+    },
+    "error": {
+      "message": "Digwyddodd gwall annisgwyl wrth ddod o hyd i'ch gwybodaeth ailgylchu cartref."
     }
   }
 }

--- a/public/translations/en.json
+++ b/public/translations/en.json
@@ -8,6 +8,7 @@
     "back": "Back",
     "search": "Search",
     "searchAgain": "Search again",
+    "tryAgain": "Try again",
     "listPlaces": "List places",
     "showMap": "Show map"
   },
@@ -201,6 +202,9 @@
         ],
         "paragraphTwo": "They will also be able to tell you when each collection is scheduled."
       }
+    },
+    "error": {
+      "message": "An unexpected error occurred whilst finding your home recycling information."
     }
   }
 }

--- a/src/components/composition/BorderedList/BorderedList.css
+++ b/src/components/composition/BorderedList/BorderedList.css
@@ -8,20 +8,20 @@ locator-bordered-list {
     font-size: var(--diamond-font-size-sm);
   }
 
-  > ul {
+  ul:first-of-type {
     list-style: none;
     margin: 0;
     padding: 0;
   }
 
-  > ul,
-  > dl {
+  ul:first-of-type,
+  dl:first-of-type {
     margin: 0;
     padding: 0;
   }
 
-  > ul > li,
-  > dl > div {
+  ul:first-of-type > li,
+  dl:first-of-type > div {
     border-top: var(--diamond-border);
     padding-block: var(--diamond-spacing);
   }
@@ -45,8 +45,8 @@ locator-bordered-list {
   }
 
   &[size='sm'] {
-    > ul > li,
-    > dl > div {
+    ul:first-of-type > li,
+    dl:first-of-type > div {
       padding-block: var(--diamond-spacing-sm);
     }
   }

--- a/src/pages/[postcode]/home/error.page.tsx
+++ b/src/pages/[postcode]/home/error.page.tsx
@@ -1,0 +1,28 @@
+import * as Sentry from '@sentry/browser';
+import { useTranslation } from 'react-i18next';
+import { Link, useParams, useRouteError } from 'react-router-dom';
+import '@etchteam/diamond-ui/control/Button/Button';
+import '@etchteam/diamond-ui/canvas/Section/Section';
+
+import '@/components/composition/Wrap/Wrap';
+import HomeRecyclingLayout from './home.layout';
+
+export default function HomeRecyclingErrorPage() {
+  const { t } = useTranslation();
+  const { postcode } = useParams();
+  const error = useRouteError();
+  Sentry.captureException(error, {
+    tags: { route: 'Home recycling error boundary' },
+  });
+
+  return (
+    <HomeRecyclingLayout>
+      <h2>{t('error.title')}</h2>
+      <p>{t('homeRecycling.error.message')}</p>
+      <p className="diamond-spacing-bottom-md">{t('error.message')}</p>
+      <diamond-button width="full-width" variant="primary">
+        <Link to={`/${postcode}/home`}>{t('actions.tryAgain')}</Link>
+      </diamond-button>
+    </HomeRecyclingLayout>
+  );
+}

--- a/src/pages/[postcode]/home/home.layout.tsx
+++ b/src/pages/[postcode]/home/home.layout.tsx
@@ -1,3 +1,4 @@
+import { ComponentChildren } from 'preact';
 import { useTranslation } from 'react-i18next';
 import { Link, NavLink, Outlet, useParams } from 'react-router-dom';
 import '@etchteam/diamond-ui/control/Button/Button';
@@ -17,10 +18,15 @@ import tArray from '@/lib/tArray';
 
 import { useHomeRecyclingLoaderData } from './home.loader';
 
-export default function HomeRecyclingLayout() {
+export default function HomeRecyclingLayout({
+  children,
+}: {
+  readonly children?: ComponentChildren;
+}) {
   const { t } = useTranslation();
   const { postcode } = useParams();
-  const { localAuthority } = useHomeRecyclingLoaderData();
+  const data = useHomeRecyclingLoaderData();
+  const la = data?.localAuthority;
 
   return (
     <locator-layout>
@@ -33,35 +39,38 @@ export default function HomeRecyclingLayout() {
           </diamond-button>
           <div>
             <h2>{t('homeRecycling.title')}</h2>
-            <p>{localAuthority.name}</p>
+            {la && <p>{la.name}</p>}
           </div>
         </locator-header-title>
       </locator-header>
       <div slot="layout-main">
-        <locator-nav-bar>
-          <nav>
-            <ul>
-              <li>
-                <NavLink to={`/${postcode}/home`} end>
-                  {t('homeRecycling.nav.collections')}
-                </NavLink>
-              </li>
-              <li>
-                <NavLink to={`/${postcode}/home/recycling-centre`}>
-                  {t('homeRecycling.nav.hwrc')}
-                </NavLink>
-              </li>
-              <li>
-                <NavLink to={`/${postcode}/home/contact`}>
-                  {t('homeRecycling.nav.contact')}
-                </NavLink>
-              </li>
-            </ul>
-          </nav>
-        </locator-nav-bar>
+        {la && (
+          <locator-nav-bar>
+            <nav>
+              <ul>
+                <li>
+                  <NavLink to={`/${postcode}/home`} end>
+                    {t('homeRecycling.nav.collections')}
+                  </NavLink>
+                </li>
+                <li>
+                  <NavLink to={`/${postcode}/home/recycling-centre`}>
+                    {t('homeRecycling.nav.hwrc')}
+                  </NavLink>
+                </li>
+                <li>
+                  <NavLink to={`/${postcode}/home/contact`}>
+                    {t('homeRecycling.nav.contact')}
+                  </NavLink>
+                </li>
+              </ul>
+            </nav>
+          </locator-nav-bar>
+        )}
         <diamond-section padding="lg">
           <locator-wrap>
             <Outlet />
+            {children}
           </locator-wrap>
         </diamond-section>
       </div>

--- a/src/pages/[postcode]/home/home.routes.tsx
+++ b/src/pages/[postcode]/home/home.routes.tsx
@@ -1,6 +1,7 @@
 import { RouteObject } from 'react-router-dom';
 
 import HomeRecyclingContactPage from './contact.page';
+import HomeRecyclingErrorPage from './error.page';
 import HomeRecyclingLayout from './home.layout';
 import homeRecyclingLoader from './home.loader';
 import HomeRecyclingPage from './home.page';
@@ -13,8 +14,12 @@ const routes: RouteObject[] = [
     element: <HomeRecyclingLayout />,
     loader: homeRecyclingLoader,
     id: 'home-recycling',
+    errorElement: <HomeRecyclingErrorPage />,
     children: [
-      { index: true, element: <HomeRecyclingPage /> },
+      {
+        index: true,
+        element: <HomeRecyclingPage />,
+      },
       {
         path: 'recycling-centre',
         element: <HomeRecyclingCentrePage />,

--- a/src/pages/[postcode]/postcode.routes.tsx
+++ b/src/pages/[postcode]/postcode.routes.tsx
@@ -10,15 +10,20 @@ import PostcodePage from './postcode.page';
 
 const routes: RouteObject[] = [
   {
-    path: '/:postcode',
-    id: 'postcode',
-    element: <PostcodePage />,
-    action: postcodeAction,
-    loader: postcodeLoader,
     errorElement: <NotFoundPage />,
+    // This loader validates the postcode for all child routes
+    loader: postcodeLoader,
+    id: 'postcode',
+    children: [
+      {
+        path: '/:postcode',
+        element: <PostcodePage />,
+        action: postcodeAction,
+      },
+      ...materialRoutes,
+      ...homeRecyclingRoutes,
+    ],
   },
-  ...materialRoutes,
-  ...homeRecyclingRoutes,
 ];
 
 export default routes;

--- a/src/pages/[postcode]/postcode.routes.tsx
+++ b/src/pages/[postcode]/postcode.routes.tsx
@@ -10,13 +10,14 @@ import PostcodePage from './postcode.page';
 
 const routes: RouteObject[] = [
   {
+    path: '/:postcode',
     errorElement: <NotFoundPage />,
     // This loader validates the postcode for all child routes
     loader: postcodeLoader,
     id: 'postcode',
     children: [
       {
-        path: '/:postcode',
+        index: true,
         element: <PostcodePage />,
         action: postcodeAction,
       },

--- a/tests/end-to-end/postcode.test.ts
+++ b/tests/end-to-end/postcode.test.ts
@@ -95,18 +95,22 @@ describeEndToEndTest('Postcode page', () => {
     const material = 'Plastic milk bottles';
     const widget = page.locator('recycling-locator');
     const input = page.locator('input').first();
-    const materialText = page.getByText(t('material.search.notFound')).first();
+    const materialText = page.getByText(material).first();
+    const recyclableText = page.getByText(t('material.hero.yes')).first();
     const materialPageTitle = page.getByText(t('material.title')).first();
 
     await widget.evaluate((node) => node.setAttribute('path', '/EX327RB'));
     await page.waitForRequest(GEOCODE_ENDPOINT);
     await expect(input).toBeVisible();
     await expect(materialText).not.toBeVisible();
+    await expect(recyclableText).not.toBeVisible();
     await expect(materialPageTitle).not.toBeVisible();
     await input.fill(material);
     await input.press('Enter');
-    await page.waitForRequest(MATERIALS_ENDPOINT);
+    await page.waitForRequest(LOCAL_AUTHORITY_ENDPOINT);
+    await page.waitForRequest(LOCATIONS_ENDPOINT);
     await expect(materialText).toBeVisible();
+    await expect(recyclableText).toBeVisible();
     await expect(materialPageTitle).toBeVisible();
   });
 });

--- a/tests/end-to-end/postcode.test.ts
+++ b/tests/end-to-end/postcode.test.ts
@@ -2,7 +2,11 @@ import { expect } from '@playwright/test';
 import { t } from 'i18next';
 import { test } from 'vitest';
 
-import { GEOCODE_ENDPOINT, GuernseyGeocodeResponse } from '../mocks/geocode';
+import {
+  GEOCODE_ENDPOINT,
+  GuernseyGeocodeResponse,
+  PostcodeGeocodeResponse,
+} from '../mocks/geocode';
 import {
   LOCAL_AUTHORITY_ENDPOINT,
   LocalAuthorityResponse,
@@ -46,7 +50,7 @@ describeEndToEndTest('Postcode page', () => {
 
   test('Invalid material search', async ({ page }) => {
     await page.route(GEOCODE_ENDPOINT, (route) => {
-      route.fulfill({ json: GuernseyGeocodeResponse });
+      route.fulfill({ json: PostcodeGeocodeResponse });
     });
 
     await page.route(MATERIALS_ENDPOINT, (route) => {
@@ -73,7 +77,7 @@ describeEndToEndTest('Postcode page', () => {
 
   test('Valid material search', async ({ page }) => {
     await page.route(GEOCODE_ENDPOINT, (route) => {
-      route.fulfill({ json: GuernseyGeocodeResponse });
+      route.fulfill({ json: PostcodeGeocodeResponse });
     });
 
     await page.route(MATERIALS_ENDPOINT, (route) => {

--- a/tests/mocks/materials.ts
+++ b/tests/mocks/materials.ts
@@ -1,7 +1,7 @@
 import config from '@/config';
 import { Material } from '@/types/locatorApi';
 
-export const MATERIALS_ENDPOINT = `${config.locatorApiPath}materials?**`;
+export const MATERIALS_ENDPOINT = `${config.locatorApiPath}materials**`;
 
 export const ValidMaterialsResponse: Material[] = [
   {

--- a/tests/mocks/materials.ts
+++ b/tests/mocks/materials.ts
@@ -1,7 +1,7 @@
 import config from '@/config';
 import { Material } from '@/types/locatorApi';
 
-export const MATERIALS_ENDPOINT = `${config.locatorApiPath}materials**`;
+export const MATERIALS_ENDPOINT = `${config.locatorApiPath}materials?**`;
 
 export const ValidMaterialsResponse: Material[] = [
   {


### PR DESCRIPTION
Adds an error page for home recycling, users could end up here if:

- There's an error fetching the local authority
- There's an error fetching the locations when the recycling centres tab is visited

This also moves the postcode loader to wrap all child routes so that the not found (location search) page is displayed anytime a child route is visited with an invalid postcode.

The `:first-of-type` fix is for bordered lists that are wrapped in `<nav>`...or anything else.