### PR TITLE
Recycle from home start view

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,5 +75,3 @@ jobs:
         run: npx playwright install --with-deps chromium
       - name: Run tests
         run: npm run test:ci
-        env:
-          DEBUG: pw:api

--- a/contributing.md
+++ b/contributing.md
@@ -85,7 +85,7 @@ The translation files can be found under /public/translations.
 
 ### Running tests
 
-Tests will run through `vitest`, for the end-to-end tests a Playwright  launches a chromium instance.
+Tests will run through `vitest`, for the end-to-end tests Playwright launches a chromium instance against the **built** dist folder.
 
 ```bash
 npm test

--- a/index.html
+++ b/index.html
@@ -47,7 +47,12 @@
         <nav>
           <ul>
             <li>
-              <a href="/">Home</a>
+              <a href="/">Start</a>
+              <ul>
+                <li>
+                  <a href="/home-recycling">Home recycling</a>
+                </li>
+              </ul>
             </li>
             <li>
               <a href="/EX327RB">Postcode</a>

--- a/public/translations/cy.json
+++ b/public/translations/cy.json
@@ -96,6 +96,9 @@
         "darganfod sut i ailgylchu eitem benodol",
         "gwirio beth allwch chi ei ailgylchu gartref"
       ]
+    },
+    "homeRecycling": {
+      "title": "Darganfyddwch beth allwch chi ei ailgylchu gartref."
     }
   },
   "postcode": {

--- a/public/translations/en.json
+++ b/public/translations/en.json
@@ -96,6 +96,9 @@
         "find out how to recycle a specific item",
         "check what you can recycle at home"
       ]
+    },
+    "homeRecycling": {
+      "title": "Find out what you can recycle from home."
     }
   },
   "postcode": {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -10,21 +10,20 @@ export interface RecyclingLocatorAttributes {
    */
   readonly locale?: Locale;
   /**
-   * Prefill the postcode to skip the start view
-   */
-  readonly postcode?: string;
-  /**
    * How to render
    * - Widget will render as an embed within a page
    * - Standalone will render as a full page and change the browser history upon navigation
    */
   readonly variant?: 'widget' | 'standalone';
   /**
-   * The base URL for the standalone variant
+   * The base path for the standalone variant
    */
   readonly basename?: string;
   /**
-   * The path to load
+   * The initial path to load
+   * - /{postcode} to pre-fill the location
+   * - /home-recycling for home recycling embeds
+   * - /material?name={materialName} to pre-select a material
    */
   readonly path?: string;
 }
@@ -37,7 +36,6 @@ export interface RecyclingLocatorAttributes {
  */
 export default function RecyclingLocator({
   locale,
-  postcode,
   variant = 'widget',
   basename = '/',
   path,
@@ -48,7 +46,6 @@ export default function RecyclingLocator({
       <article className={`recycling-locator-variant-${variant}`}>
         <Entrypoint
           locale={locale}
-          postcode={postcode}
           variant={variant}
           basename={basename}
           path={path}

--- a/src/lib/getStartPath.ts
+++ b/src/lib/getStartPath.ts
@@ -1,18 +1,10 @@
 import { RecyclingLocatorAttributes } from '@/index';
 
-import PostcodeResolver from './PostcodeResolver';
-
 export default function getStartPath(
   attributes: RecyclingLocatorAttributes,
 ): string {
-  const { postcode } = attributes;
-
   if (attributes.path) {
     return attributes.path;
-  }
-
-  if (attributes.postcode) {
-    return `/${PostcodeResolver.formatPostcode(postcode)}`;
   }
 
   return '/';

--- a/src/pages/LocationForm.tsx
+++ b/src/pages/LocationForm.tsx
@@ -1,0 +1,30 @@
+import { useSignal } from '@preact/signals';
+import { useTranslation } from 'react-i18next';
+import { Form } from 'react-router-dom';
+
+export default function LocationForm({
+  label,
+  cta,
+}: {
+  readonly label?: string;
+  readonly cta?: string;
+}) {
+  const { t } = useTranslation();
+  const submitting = useSignal(false);
+
+  return (
+    <Form method="post" onSubmit={() => (submitting.value = true)}>
+      <diamond-form-group class="diamond-spacing-bottom-md">
+        <label htmlFor="location-input">{label ?? t('start.label')}</label>
+        <locator-location-input
+          placeholder={t('components.locationInput.placeholder')}
+        ></locator-location-input>
+      </diamond-form-group>
+      <diamond-button width="full-width" variant="primary">
+        <button type="submit" disabled={submitting.value}>
+          {cta ?? t('start.cta')}
+        </button>
+      </diamond-button>
+    </Form>
+  );
+}

--- a/src/pages/home-recycling.page.tsx
+++ b/src/pages/home-recycling.page.tsx
@@ -10,7 +10,7 @@ import StartLayout from '@/pages/start.layout';
 
 import LocationForm from './LocationForm';
 
-export default function StartPage() {
+export default function HomeRecyclingStartPage() {
   const { t } = useTranslation();
 
   useEffect(() => {
@@ -22,7 +22,7 @@ export default function StartPage() {
     <StartLayout>
       <locator-wrap>
         <diamond-section padding="lg">
-          <h2>{t('start.title')}</h2>
+          <h2>{t('start.homeRecycling.title')}</h2>
           <LocationForm />
         </diamond-section>
       </locator-wrap>

--- a/src/pages/home-recycling.page.tsx
+++ b/src/pages/home-recycling.page.tsx
@@ -1,4 +1,3 @@
-import { useEffect } from 'preact/hooks';
 import { useTranslation } from 'react-i18next';
 import '@etchteam/diamond-ui/composition/FormGroup/FormGroup';
 import '@etchteam/diamond-ui/control/Button/Button';
@@ -12,11 +11,6 @@ import LocationForm from './LocationForm';
 
 export default function HomeRecyclingStartPage() {
   const { t } = useTranslation();
-
-  useEffect(() => {
-    const host = document.querySelector('recycling-locator');
-    host.dispatchEvent(new CustomEvent('ready'));
-  }, []);
 
   return (
     <StartLayout>

--- a/src/pages/not-found.page.tsx
+++ b/src/pages/not-found.page.tsx
@@ -1,6 +1,5 @@
-import { useSignal } from '@preact/signals';
 import { useTranslation } from 'react-i18next';
-import { Form, useRouteError, ErrorResponse } from 'react-router-dom';
+import { useRouteError, ErrorResponse } from 'react-router-dom';
 import '@etchteam/diamond-ui/composition/FormGroup/FormGroup';
 import '@etchteam/diamond-ui/control/Button/Button';
 import '@etchteam/diamond-ui/canvas/Section/Section';
@@ -10,6 +9,8 @@ import '@/components/canvas/Tip/Tip';
 import '@/components/control/LocationInput/LocationInput';
 import PostCodeResolver from '@/lib/PostcodeResolver';
 import StartLayout from '@/pages/start.layout';
+
+import LocationForm from './LocationForm';
 
 function Aside() {
   const { t } = useTranslation();
@@ -55,7 +56,6 @@ function Aside() {
 export default function NotFoundPage() {
   const { t } = useTranslation();
   const error = useRouteError() as ErrorResponse | undefined;
-  const submitting = useSignal(false);
 
   if (error && error.status !== 404) {
     // If this isn't a 404, bubble the exception up to the generic error boundary
@@ -70,19 +70,7 @@ export default function NotFoundPage() {
         <diamond-section padding="lg">
           <h2>{t(`notFound.title.${notInUk ? 'notInTheUK' : 'default'}`)}</h2>
           {notInUk && <p>{t('notFound.ukOnly')}</p>}
-          <Form method="post" onSubmit={() => (submitting.value = true)}>
-            <diamond-form-group class="diamond-spacing-bottom-md">
-              <label htmlFor="location-input">{t('notFound.label')}</label>
-              <locator-location-input
-                placeholder={t('components.locationInput.placeholder')}
-              ></locator-location-input>
-            </diamond-form-group>
-            <diamond-button width="full-width" variant="primary">
-              <button type="submit" disabled={submitting.value}>
-                {t('notFound.cta')}
-              </button>
-            </diamond-button>
-          </Form>
+          <LocationForm label={t('notFound.label')} cta={t('notFound.cta')} />
         </diamond-section>
       </locator-wrap>
     </StartLayout>

--- a/src/pages/root.layout.tsx
+++ b/src/pages/root.layout.tsx
@@ -29,5 +29,12 @@ export default function RootLayout() {
     return null;
   }
 
+  // Send a ready event when the first route renders
+  // this is delayed by 50ms to give the outer page time to add an event listener
+  setTimeout(() => {
+    const host = document.querySelector('recycling-locator');
+    host.dispatchEvent(new CustomEvent('ready'));
+  }, 50);
+
   return <Outlet />;
 }

--- a/src/pages/start.action.ts
+++ b/src/pages/start.action.ts
@@ -2,26 +2,44 @@ import { ActionFunctionArgs, redirect } from 'react-router-dom';
 
 import PostCodeResolver from '@/lib/PostcodeResolver';
 
-export default async function startAction({ request }: ActionFunctionArgs) {
+function handleError(error: Error) {
+  if (error instanceof Error) {
+    if (
+      [
+        PostCodeResolver.ERROR_NOT_IN_UK,
+        PostCodeResolver.ERROR_POSTCODE_NOT_FOUND,
+        PostCodeResolver.ERROR_SEARCH_FAILED,
+      ].includes(error.message)
+    ) {
+      throw new Response(error.message, { status: 404 });
+    }
+  }
+
+  throw error;
+}
+
+export async function resolvePostcode(request: ActionFunctionArgs['request']) {
   const formData = await request.formData();
   const location = formData.get('location') as string;
+  return PostCodeResolver.fromString(location);
+}
 
+export async function homeRecyclingStartAction({
+  request,
+}: ActionFunctionArgs) {
   try {
-    const postcode = await PostCodeResolver.fromString(location);
+    const postcode = await resolvePostcode(request);
+    return redirect(`/${postcode}/home`);
+  } catch (error) {
+    handleError(error);
+  }
+}
+
+export default async function startAction({ request }: ActionFunctionArgs) {
+  try {
+    const postcode = await resolvePostcode(request);
     return redirect(`/${postcode}`);
   } catch (error) {
-    if (error instanceof Error) {
-      if (
-        [
-          PostCodeResolver.ERROR_NOT_IN_UK,
-          PostCodeResolver.ERROR_POSTCODE_NOT_FOUND,
-          PostCodeResolver.ERROR_SEARCH_FAILED,
-        ].includes(error.message)
-      ) {
-        throw new Response(error.message, { status: 404 });
-      }
-    }
-
-    throw error;
+    handleError(error);
   }
 }

--- a/src/pages/start.page.tsx
+++ b/src/pages/start.page.tsx
@@ -1,4 +1,3 @@
-import { useEffect } from 'preact/hooks';
 import { useTranslation } from 'react-i18next';
 import '@etchteam/diamond-ui/composition/FormGroup/FormGroup';
 import '@etchteam/diamond-ui/control/Button/Button';
@@ -12,11 +11,6 @@ import LocationForm from './LocationForm';
 
 export default function StartPage() {
   const { t } = useTranslation();
-
-  useEffect(() => {
-    const host = document.querySelector('recycling-locator');
-    host.dispatchEvent(new CustomEvent('ready'));
-  }, []);
 
   return (
     <StartLayout>

--- a/src/pages/start.routes.tsx
+++ b/src/pages/start.routes.tsx
@@ -1,7 +1,8 @@
 import { RouteObject } from 'react-router-dom';
 
+import HomeRecyclingStartPage from './home-recycling.page';
 import NotFoundPage from './not-found.page';
-import startAction from './start.action';
+import startAction, { homeRecyclingStartAction } from './start.action';
 import StartPage from './start.page';
 
 const routes: RouteObject[] = [
@@ -9,6 +10,12 @@ const routes: RouteObject[] = [
     path: '/',
     element: <StartPage />,
     action: startAction,
+    errorElement: <NotFoundPage />,
+  },
+  {
+    path: '/home-recycling',
+    element: <HomeRecyclingStartPage />,
+    action: homeRecyclingStartAction,
     errorElement: <NotFoundPage />,
   },
 ];

--- a/src/styles/tokens/button.css
+++ b/src/styles/tokens/button.css
@@ -19,3 +19,7 @@
 
   --diamond-button-text-background-hover: var(--theme-background-accent);
 }
+
+diamond-button[variant='primary'] {
+  --diamond-button-font-weight: var(--diamond-font-weight-bold);
+}

--- a/src/types/vitest.d.ts
+++ b/src/types/vitest.d.ts
@@ -1,12 +1,10 @@
 import 'vitest';
-import type { Browser, Page } from 'playwright';
-import type { PreviewServer } from 'vite';
+import type { Locator, Page } from 'playwright';
 
 declare module 'vitest' {
   export interface TestContext {
     // This context is only available in end-to-end tests
-    server: PreviewServer;
-    browser: Browser;
     page: Page;
+    widget: Locator;
   }
 }

--- a/tests/end-to-end/material.test.ts
+++ b/tests/end-to-end/material.test.ts
@@ -11,7 +11,7 @@ import describeEndToEndTest from '../utils/describeEndToEndTest';
 import { DryScheme } from '@/types/locatorApi';
 
 describeEndToEndTest('Material page', () => {
-  test('Single scheme + location options', async ({ page }) => {
+  test('Single scheme + location options', async ({ page, widget }) => {
     await page.route(LOCAL_AUTHORITY_ENDPOINT, (route) => {
       route.fulfill({ json: LocalAuthorityResponse });
     });
@@ -20,7 +20,6 @@ describeEndToEndTest('Material page', () => {
       route.fulfill({ json: LocationsResponse });
     });
 
-    const widget = page.locator('recycling-locator');
     const recyclableText = page.getByText(t('material.hero.yes')).first();
     const homeText = page
       .getByText(t('material.recycleAtHome.oneScheme.collection', { count: 1 }))
@@ -43,7 +42,7 @@ describeEndToEndTest('Material page', () => {
     await expect(locationsText).toBeVisible();
   });
 
-  test('Some home recycling options', async ({ page }) => {
+  test('Some home recycling options', async ({ page, widget }) => {
     await page.route(LOCAL_AUTHORITY_ENDPOINT, (route) => {
       const dryStreams = LocalAuthorityResponse.dryStreams.concat([
         {
@@ -67,7 +66,6 @@ describeEndToEndTest('Material page', () => {
       route.fulfill({ json: LocationsResponse });
     });
 
-    const widget = page.locator('recycling-locator');
     const recyclableText = page.getByText(t('material.hero.yes')).first();
     const schemeOneText = page
       .getByText(LocalAuthorityResponse.dryStreams[0].name)
@@ -92,7 +90,7 @@ describeEndToEndTest('Material page', () => {
     await expect(locationsText).toBeVisible();
   });
 
-  test('All home recycling options', async ({ page }) => {
+  test('All home recycling options', async ({ page, widget }) => {
     await page.route(LOCAL_AUTHORITY_ENDPOINT, (route) => {
       const dryStreams = LocalAuthorityResponse.dryStreams.concat([
         {
@@ -138,7 +136,6 @@ describeEndToEndTest('Material page', () => {
       route.fulfill({ json: LocationsResponse });
     });
 
-    const widget = page.locator('recycling-locator');
     const recyclableText = page.getByText(t('material.hero.yes')).first();
     const schemeOneText = page
       .getByText(LocalAuthorityResponse.dryStreams[0].name)
@@ -163,7 +160,7 @@ describeEndToEndTest('Material page', () => {
     await expect(locationsText).toBeVisible();
   });
 
-  test('No home recycling', async ({ page }) => {
+  test('No home recycling', async ({ page, widget }) => {
     await page.route(LOCAL_AUTHORITY_ENDPOINT, (route) => {
       route.fulfill({ json: LocalAuthorityResponse });
     });
@@ -172,7 +169,6 @@ describeEndToEndTest('Material page', () => {
       route.fulfill({ json: LocationsResponse });
     });
 
-    const widget = page.locator('recycling-locator');
     const recyclableText = page.getByText(t('material.hero.yes')).first();
     const homeText = page
       .getByText(t('material.recycleAtHome.noSchemes.content'))
@@ -192,7 +188,7 @@ describeEndToEndTest('Material page', () => {
     await expect(locationsText).toBeVisible();
   });
 
-  test('Not recyclable', async ({ page }) => {
+  test('Not recyclable', async ({ page, widget }) => {
     await page.route(LOCAL_AUTHORITY_ENDPOINT, (route) => {
       route.fulfill({ json: LocalAuthorityResponse });
     });
@@ -201,7 +197,6 @@ describeEndToEndTest('Material page', () => {
       route.fulfill({ json: { items: [] } });
     });
 
-    const widget = page.locator('recycling-locator');
     const recyclableText = page.getByText(t('material.hero.no')).first();
     const homeText = page
       .getByText(t('material.recycleAtHome.noSchemes.content'))

--- a/tests/end-to-end/postcode.test.ts
+++ b/tests/end-to-end/postcode.test.ts
@@ -20,13 +20,12 @@ import {
 import describeEndToEndTest from '../utils/describeEndToEndTest';
 
 describeEndToEndTest('Postcode page', () => {
-  test('Load route with invalid postcode', async ({ page }) => {
+  test('Load route with invalid postcode', async ({ page, widget }) => {
     await page.route(GEOCODE_ENDPOINT, (route) => {
       route.fulfill({ json: GuernseyGeocodeResponse });
     });
 
     const notInUk = page.getByText(t('notFound.title.notInTheUK')).first();
-    const widget = page.locator('recycling-locator');
 
     await expect(notInUk).not.toBeVisible();
     await widget.evaluate((node) => node.setAttribute('path', '/EX327RB'));
@@ -34,12 +33,11 @@ describeEndToEndTest('Postcode page', () => {
     await expect(notInUk).toBeVisible();
   });
 
-  test('Start route with invalid postcode', async ({ page }) => {
+  test('Start route with invalid postcode', async ({ page, widget }) => {
     await page.route(GEOCODE_ENDPOINT, (route) => {
       route.fulfill({ json: GuernseyGeocodeResponse });
     });
 
-    const widget = page.locator('recycling-locator');
     const notInUk = page.getByText(t('notFound.title.notInTheUK')).first();
 
     await expect(notInUk).not.toBeVisible();
@@ -48,7 +46,7 @@ describeEndToEndTest('Postcode page', () => {
     await expect(notInUk).toBeVisible();
   });
 
-  test('Invalid material search', async ({ page }) => {
+  test('Invalid material search', async ({ page, widget }) => {
     await page.route(GEOCODE_ENDPOINT, (route) => {
       route.fulfill({ json: PostcodeGeocodeResponse });
     });
@@ -58,7 +56,6 @@ describeEndToEndTest('Postcode page', () => {
     });
 
     const material = 'Not a material';
-    const widget = page.locator('recycling-locator');
     const input = page.locator('input').first();
     const notFound = page.getByText(t('material.search.notFound')).first();
     const materialText = page.getByText(t('material.search.notFound')).first();
@@ -75,7 +72,7 @@ describeEndToEndTest('Postcode page', () => {
     await expect(materialText).toBeVisible();
   });
 
-  test('Valid material search', async ({ page }) => {
+  test('Valid material search', async ({ page, widget }) => {
     await page.route(GEOCODE_ENDPOINT, (route) => {
       route.fulfill({ json: PostcodeGeocodeResponse });
     });
@@ -93,7 +90,6 @@ describeEndToEndTest('Postcode page', () => {
     });
 
     const material = 'Plastic milk bottles';
-    const widget = page.locator('recycling-locator');
     const input = page.locator('input').first();
     const materialText = page.getByText(material).first();
     const recyclableText = page.getByText(t('material.hero.yes')).first();

--- a/tests/end-to-end/postcode.test.ts
+++ b/tests/end-to-end/postcode.test.ts
@@ -39,11 +39,11 @@ describeEndToEndTest('Postcode page', () => {
       route.fulfill({ json: GuernseyGeocodeResponse });
     });
 
-    const notInUk = page.getByText(t('notFound.title.notInTheUK')).first();
     const widget = page.locator('recycling-locator');
+    const notInUk = page.getByText(t('notFound.title.notInTheUK')).first();
 
     await expect(notInUk).not.toBeVisible();
-    await widget.evaluate((node) => node.setAttribute('postcode', 'EX327RB'));
+    await widget.evaluate((node) => node.setAttribute('path', '/GU375EY'));
     await page.waitForRequest(GEOCODE_ENDPOINT);
     await expect(notInUk).toBeVisible();
   });

--- a/tests/end-to-end/start.test.ts
+++ b/tests/end-to-end/start.test.ts
@@ -108,7 +108,6 @@ describeEndToEndTest('Start page', () => {
   });
 
   test('Home recycling start', async ({ page, widget }) => {
-    console.log(widget);
     await page.route(GEOCODE_ENDPOINT, (route) => {
       route.fulfill({ json: PostcodeGeocodeResponse });
     });
@@ -130,19 +129,12 @@ describeEndToEndTest('Start page', () => {
     await widget.evaluate((node) =>
       node.setAttribute('path', '/home-recycling'),
     );
-    console.log(1);
     await expect(homeStartPageTitle).toBeVisible();
-    console.log(2);
     await expect(input).toBeVisible();
-    console.log(3);
     await expect(localAuthority).not.toBeVisible();
-    console.log(4);
     await input.fill('Barnstaple');
-    console.log(5);
     await input.press('Enter');
-    console.log(6);
     await page.waitForRequest(LOCAL_AUTHORITY_ENDPOINT);
-    console.log(7);
     await expect(localAuthority).toBeVisible();
   });
 });

--- a/tests/end-to-end/start.test.ts
+++ b/tests/end-to-end/start.test.ts
@@ -8,6 +8,10 @@ import {
   PostcodeGeocodeResponse,
 } from '../mocks/geocode';
 import {
+  LOCAL_AUTHORITY_ENDPOINT,
+  LocalAuthorityResponse,
+} from '../mocks/localAuthority';
+import {
   POSTCODE_ENDPOINT,
   InvalidPostcodeResponse,
   ValidPostcodeResponse,
@@ -101,5 +105,37 @@ describeEndToEndTest('Start page', () => {
     await page.waitForRequest(GEOCODE_ENDPOINT);
     await page.waitForRequest(POSTCODE_ENDPOINT);
     await expect(notFoundPageTitle).toBeVisible();
+  });
+
+  test('Home recycling start', async ({ page }) => {
+    await page.route(GEOCODE_ENDPOINT, (route) => {
+      route.fulfill({ json: PostcodeGeocodeResponse });
+    });
+
+    await page.route(POSTCODE_ENDPOINT, (route) => {
+      route.fulfill({ json: ValidPostcodeResponse });
+    });
+
+    await page.route(LOCAL_AUTHORITY_ENDPOINT, (route) => {
+      route.fulfill({ json: LocalAuthorityResponse });
+    });
+
+    const widget = page.locator('recycling-locator');
+    const input = page.locator('input').first();
+    const homeStartPageTitle = page
+      .getByText(t('start.homeRecycling.title'))
+      .first();
+    const localAuthority = page.getByText(LocalAuthorityResponse.name).first();
+
+    await widget.evaluate((node) =>
+      node.setAttribute('path', '/home-recycling'),
+    );
+    await expect(homeStartPageTitle).toBeVisible();
+    await expect(input).toBeVisible();
+    await expect(localAuthority).not.toBeVisible();
+    await input.fill('Barnstaple');
+    await input.press('Enter');
+    await page.waitForRequest(LOCAL_AUTHORITY_ENDPOINT);
+    await expect(localAuthority).toBeVisible();
   });
 });

--- a/tests/end-to-end/start.test.ts
+++ b/tests/end-to-end/start.test.ts
@@ -107,7 +107,8 @@ describeEndToEndTest('Start page', () => {
     await expect(notFoundPageTitle).toBeVisible();
   });
 
-  test('Home recycling start', async ({ page }) => {
+  test('Home recycling start', async ({ page, widget }) => {
+    console.log(widget);
     await page.route(GEOCODE_ENDPOINT, (route) => {
       route.fulfill({ json: PostcodeGeocodeResponse });
     });
@@ -120,7 +121,6 @@ describeEndToEndTest('Start page', () => {
       route.fulfill({ json: LocalAuthorityResponse });
     });
 
-    const widget = page.locator('recycling-locator');
     const input = page.locator('input').first();
     const homeStartPageTitle = page
       .getByText(t('start.homeRecycling.title'))
@@ -130,12 +130,19 @@ describeEndToEndTest('Start page', () => {
     await widget.evaluate((node) =>
       node.setAttribute('path', '/home-recycling'),
     );
+    console.log(1);
     await expect(homeStartPageTitle).toBeVisible();
+    console.log(2);
     await expect(input).toBeVisible();
+    console.log(3);
     await expect(localAuthority).not.toBeVisible();
+    console.log(4);
     await input.fill('Barnstaple');
+    console.log(5);
     await input.press('Enter');
+    console.log(6);
     await page.waitForRequest(LOCAL_AUTHORITY_ENDPOINT);
+    console.log(7);
     await expect(localAuthority).toBeVisible();
   });
 });

--- a/tests/unit/getStartPath.test.ts
+++ b/tests/unit/getStartPath.test.ts
@@ -6,11 +6,6 @@ test('Default path is /', () => {
   expect(getStartPath({})).toBe('/');
 });
 
-test('Postcode attribute is the path if provided', () => {
-  expect(getStartPath({ postcode: 'eX32 7rB' })).toBe('/EX327RB');
-});
-
 test('Path attribute is used if provided', () => {
   expect(getStartPath({ path: '/path' })).toBe('/path');
-  expect(getStartPath({ postcode: 'EX327RB', path: '/path' })).toBe('/path');
 });

--- a/tests/utils/describeEndToEndTest.ts
+++ b/tests/utils/describeEndToEndTest.ts
@@ -33,8 +33,17 @@ export default function describeEndToEndTest(
         route.fulfill({ json: en });
       });
       page.goto(`http://localhost:${PORT}`);
+      const widget = page.locator('recycling-locator');
+      await widget.evaluate(async (node) => {
+        return new Promise((resolve) => {
+          node.addEventListener('ready', resolve);
+          // If ready hasn't emitted after 2 seconds, resolve anyway
+          setTimeout(resolve, 2000);
+        });
+      });
 
       context.page = page;
+      context.widget = widget;
     });
 
     afterEach(async () => {


### PR DESCRIPTION
- Adds the /home-recycling start path
- Moves the location form out to a component as it's now included on 3 paths
- Makes primary buttons bold (fixes WRAP-263)
- Removes the postcode attribute in favour of everyone using the path attribute instead. This removes the path abstraction so it's more exposed to invalid paths but avoids conflicts between which route to render based on which combination of attributes is provided so overall I think it's easier to use, document and work with 