### PR TITLE
Split home collections by property type

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -87,11 +87,29 @@ The translation files can be found under /public/translations.
 
 Tests will run through `vitest`, for the end-to-end tests Playwright launches a chromium instance against the **built** dist folder.
 
+#### Unit tests
+
+To run unit tests only use the unit test filter.
+
 ```bash
-npm test
+npm test unit
 ```
 
-To enable end-to-end test debugging use the debug command.
+#### End to end tests
+
+Build the app in non-library mode.
+
+```bash
+TEST=true npm run build
+```
+
+Then run the tests, filter by end-to-end to run only the E2E tests
+
+```bash
+npm test end-to-end
+```
+
+To enable E2E test debugging use the debug command.
 
 ```bash
 npm run test:debug

--- a/public/translations/cy.json
+++ b/public/translations/cy.json
@@ -127,16 +127,16 @@
     },
     "recycleAtHome": {
       "cta": "Gwiriwch eich casgliad cartref",
-      "noSchemes": {
+      "noProperties": {
         "title": "Ni ellir ailgylchu'r eitem hon gartref",
         "content": "Gwiriwch beth allwch chi ei roi yn eich biniau ailgylchu cartref ac a oes gennych chi gasgliad gwastraff bwyd a gardd."
       },
-      "manySchemes": {
+      "manyProperties": {
         "title": "Ailgylchu gartref",
         "collectionSome": "Cesglir yr eitem hon o rai eiddo yn yr ardal.",
         "collectionAll": "Cesglir yr eitem hon o bob eiddo yn yr ardal."
       },
-      "oneScheme": {
+      "oneProperty": {
         "title": "Ailgylchu gartref",
         "collection_one": "Cesglir yr eitem hon yn y bin hwn:",
         "collection_other": "Cesglir yr eitem hon yn y biniau hyn:",

--- a/public/translations/cy.json
+++ b/public/translations/cy.json
@@ -52,6 +52,10 @@
       "#9946db": "Porffor",
       "#89c1ab": "Wy hwyaden",
       "#ffffff00": "Tryloyw"
+    },
+    "schemeContainerSummary": {
+      "otherContainers_one": "+1 bin arall",
+      "otherContainers_other": "+{{count}} bin arall"
     }
   },
   "error": {
@@ -139,9 +143,7 @@
       "oneProperty": {
         "title": "Ailgylchu gartref",
         "collection_one": "Cesglir yr eitem hon yn y bin hwn:",
-        "collection_other": "Cesglir yr eitem hon yn y biniau hyn:",
-        "otherContainers_one": "+1 bin arall",
-        "otherContainers_other": "+{{count}} bin arall"
+        "collection_other": "Cesglir yr eitem hon yn y biniau hyn:"
       }
     },
     "nearbyPlaces": {

--- a/public/translations/en.json
+++ b/public/translations/en.json
@@ -52,6 +52,10 @@
       "#9946db": "Purple",
       "#89c1ab": "Duck egg",
       "#ffffff00": "Transparent"
+    },
+    "schemeContainerSummary": {
+      "otherContainers_one": "+1 other bin",
+      "otherContainers_other": "+{{count}} other bins"
     }
   },
   "error": {
@@ -139,9 +143,7 @@
       "oneProperty": {
         "title": "Recycle at home",
         "collection_one": "This item is collected in this bin:",
-        "collection_other": "This item is collected in these bins:",
-        "otherContainers_one": "+1 other bin",
-        "otherContainers_other": "+{{count}} other bins"
+        "collection_other": "This item is collected in these bins:"
       }
     },
     "nearbyPlaces": {

--- a/public/translations/en.json
+++ b/public/translations/en.json
@@ -127,16 +127,16 @@
     },
     "recycleAtHome": {
       "cta": "Check your home collection",
-      "noSchemes": {
+      "noProperties": {
         "title": "This item cannot be recycled at home",
         "content": "Check what you can put in your home recycling bins and if you have a food and garden waste collection."
       },
-      "manySchemes": {
+      "manyProperties": {
         "title": "Recycle at home",
         "collectionSome": "This item is collected from <bold>some properties</bold> in the area.",
         "collectionAll": "This item is collected from <bold>all properties</bold> in the area."
       },
-      "oneScheme": {
+      "oneProperty": {
         "title": "Recycle at home",
         "collection_one": "This item is collected in this bin:",
         "collection_other": "This item is collected in these bins:",

--- a/src/components/canvas/Loading/Loading.css
+++ b/src/components/canvas/Loading/Loading.css
@@ -1,8 +1,11 @@
 locator-loading {
   background: var(--diamond-theme-background-muted);
   display: grid;
-  inset: 0;
   place-content: center;
-  position: absolute;
   text-align: center;
+
+  @container (width >= 768px) {
+    inset: 0;
+    position: absolute;
+  }
 }

--- a/src/components/composition/BorderedList/BorderedList.css
+++ b/src/components/composition/BorderedList/BorderedList.css
@@ -1,3 +1,4 @@
+/* stylelint-disable selector-max-compound-selectors */
 locator-bordered-list {
   display: block;
 
@@ -8,29 +9,32 @@ locator-bordered-list {
     font-size: var(--diamond-font-size-sm);
   }
 
-  ul:first-of-type {
+  > nav > ul,
+  > ul {
     list-style: none;
     margin: 0;
     padding: 0;
   }
 
-  ul:first-of-type,
-  dl:first-of-type {
+  > nav > ul,
+  > ul,
+  > dl {
     margin: 0;
     padding: 0;
   }
 
-  ul:first-of-type > li,
-  dl:first-of-type > div {
+  > nav > ul > li,
+  > ul > li,
+  > dl > div {
     border-top: var(--diamond-border);
     padding-block: var(--diamond-spacing);
   }
 
-  dt {
+  > dl > div > dt {
     font-weight: var(--diamond-font-weight-bold);
   }
 
-  dd {
+  > dl > div > dd {
     margin: 0;
   }
 
@@ -45,8 +49,9 @@ locator-bordered-list {
   }
 
   &[size='sm'] {
-    ul:first-of-type > li,
-    dl:first-of-type > div {
+    > nav > ul > li,
+    > ul > li,
+    > dl > div {
       padding-block: var(--diamond-spacing-sm);
     }
   }

--- a/src/components/composition/BorderedList/BorderedList.css
+++ b/src/components/composition/BorderedList/BorderedList.css
@@ -1,4 +1,3 @@
-/* stylelint-disable selector-max-compound-selectors */
 locator-bordered-list {
   display: block;
 

--- a/src/components/composition/IconText/IconText.css
+++ b/src/components/composition/IconText/IconText.css
@@ -3,6 +3,10 @@ locator-icon-text {
   gap: var(--diamond-spacing-sm);
   grid-template-columns: auto 1fr;
 
+  :first-child {
+    align-self: flex-start;
+  }
+
   :last-child {
     align-self: center;
     margin-block-end: 0;

--- a/src/components/content/Icon/Icon.tsx
+++ b/src/components/content/Icon/Icon.tsx
@@ -16,6 +16,7 @@ export interface IconAttributes {
     | 'search'
     | 'map'
     | 'arrow-left'
+    | 'arrow-right'
     | 'warning'
     | 'cross-circle'
     | 'tick-circle'

--- a/src/components/content/Icon/svg/arrow-right.svg
+++ b/src/components/content/Icon/svg/arrow-right.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M16.175 13H4V11H16.175L10.575 5.4L12 4L20 12L12 20L10.575 18.6L16.175 13Z" fill="black"/>
+</svg>

--- a/src/components/control/Details/Details.css
+++ b/src/components/control/Details/Details.css
@@ -39,9 +39,39 @@ locator-details {
         padding: 0;
       }
 
-      /* stylelint-disable-next-line selector-max-compound-selectors */
       > summary locator-icon {
         transform: rotate(180deg);
+      }
+    }
+  }
+
+  &[menu] details {
+    border: 0 none;
+    padding: 0;
+
+    > summary {
+      padding: 0;
+    }
+
+    ul {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+    }
+
+    a {
+      color: var(--diamond-theme-color-muted);
+      text-decoration: none;
+      transition: color var(--diamond-transition);
+
+      locator-icon {
+        color: var(--color-grey-light);
+        transition: color var(--diamond-transition);
+      }
+
+      &:hover,
+      &:hover locator-icon {
+        color: var(--diamond-theme-color-hover);
       }
     }
   }

--- a/src/components/control/Details/Details.stories.tsx
+++ b/src/components/control/Details/Details.stories.tsx
@@ -26,3 +26,21 @@ export const Details: StoryObj = {
     </locator-details>
   ),
 };
+
+export const Menu: StoryObj = {
+  render: () => (
+    <locator-details menu>
+      <details>
+        <summary>
+          Details
+          <locator-icon icon="expand" />
+        </summary>
+        <ul>
+          <li>Item 1</li>
+          <li>Item 2</li>
+          <li>Item 3</li>
+        </ul>
+      </details>
+    </locator-details>
+  ),
+};

--- a/src/components/control/Details/Details.tsx
+++ b/src/components/control/Details/Details.tsx
@@ -1,9 +1,13 @@
 import { CustomElement } from '@/types/customElement';
 
+export interface DetailsAttributes {
+  readonly menu?: boolean;
+}
+
 declare module 'react' {
   namespace JSX {
     interface IntrinsicElements {
-      'locator-details': CustomElement;
+      'locator-details': CustomElement<DetailsAttributes>;
     }
   }
 }

--- a/src/components/template/SchemeContainerSummary/SchemeContainerSummary.tsx
+++ b/src/components/template/SchemeContainerSummary/SchemeContainerSummary.tsx
@@ -1,0 +1,44 @@
+import { useTranslation } from 'react-i18next';
+
+import containerName from '@/lib/containerName';
+import { Container } from '@/types/locatorApi';
+
+export default function SchemeContainerSummary({
+  containers,
+  limit = 2,
+}: {
+  readonly containers: Container[];
+  readonly limit?: number;
+}) {
+  const { t } = useTranslation();
+  const firstContainers = containers.slice(0, limit);
+  const remainingContainers = containers.slice(limit);
+
+  return (
+    <ul role="list" className="list-style-none diamond-spacing-bottom-md">
+      {firstContainers.map((container) => (
+        <li key={container.name} className="diamond-spacing-bottom-sm">
+          <locator-container>
+            <locator-container-svg
+              name={container.name}
+              body-colour={container.bodyColour}
+              lid-colour={container.lidColour}
+            />
+            <locator-container-content>
+              <locator-container-name>
+                {containerName(container)}
+              </locator-container-name>
+            </locator-container-content>
+          </locator-container>
+        </li>
+      ))}
+      {remainingContainers.length > 0 && (
+        <li>
+          {t('components.schemeContainerSummary.otherContainers', {
+            count: remainingContainers.length,
+          })}
+        </li>
+      )}
+    </ul>
+  );
+}

--- a/src/lib/getPropertiesByMaterial.ts
+++ b/src/lib/getPropertiesByMaterial.ts
@@ -1,0 +1,36 @@
+import isEmpty from 'lodash/isEmpty';
+
+import { LocalAuthority, LocalAuthorityProperty } from '@/types/locatorApi';
+
+function hasSchemeWithMaterial(
+  materialId: number,
+  property: LocalAuthorityProperty[],
+): boolean {
+  return property.some((scheme) =>
+    scheme.containers.some((container) =>
+      container.materials?.some((material) => material.id === materialId),
+    ),
+  );
+}
+
+export default function getPropertiesByMaterial(
+  materialId: number,
+  properties: LocalAuthority['properties'],
+): LocalAuthority['properties'] | undefined {
+  const propertyTypes = Object.keys(properties);
+
+  const foundProperties = propertyTypes.reduce(
+    (propertiesWithMaterial, propertyType) => {
+      const property = properties[propertyType];
+
+      if (hasSchemeWithMaterial(materialId, property)) {
+        propertiesWithMaterial[propertyType] = property;
+      }
+
+      return propertiesWithMaterial;
+    },
+    {},
+  );
+
+  return isEmpty(foundProperties) ? undefined : foundProperties;
+}

--- a/src/lib/getPropertyDisplayName.ts
+++ b/src/lib/getPropertyDisplayName.ts
@@ -1,0 +1,12 @@
+import { LocalAuthorityProperty } from '@/types/locatorApi';
+
+/**
+ * If there's a dry scheme return its name
+ * otherwise return the name of the first scheme
+ */
+export default function getPropertyDisplayName(
+  property: LocalAuthorityProperty[],
+): string {
+  const dryScheme = property.find((scheme) => scheme.type === 'Dry');
+  return dryScheme?.name ?? property[0].name;
+}

--- a/src/lib/getPropertyDisplayName.ts
+++ b/src/lib/getPropertyDisplayName.ts
@@ -1,4 +1,4 @@
-import { LocalAuthorityProperty } from '@/types/locatorApi';
+import { LocalAuthorityProperty, PROPERTY_TYPE } from '@/types/locatorApi';
 
 /**
  * If there's a dry scheme return its name
@@ -8,5 +8,11 @@ export default function getPropertyDisplayName(
   property: LocalAuthorityProperty[],
 ): string {
   const dryScheme = property.find((scheme) => scheme.type === 'Dry');
+
+  if (dryScheme?.name === PROPERTY_TYPE.ALL) {
+    // Avoid displaying "All properties" as the display name if we can help
+    return property[0]?.name;
+  }
+
   return dryScheme?.name ?? property[0].name;
 }

--- a/src/pages/[postcode]/home/ContainerList.tsx
+++ b/src/pages/[postcode]/home/ContainerList.tsx
@@ -7,25 +7,21 @@ import '@etchteam/diamond-ui/composition/Enter/Enter';
 import '@/components/content/Container/Container';
 import '@/components/control/Details/Details';
 import containerName from '@/lib/containerName';
-import { LocalAuthority, OrganicStreamContainer } from '@/types/locatorApi';
+import { LocalAuthorityProperty, Container } from '@/types/locatorApi';
 
 function useContainers(
-  la: LocalAuthority,
+  property: LocalAuthorityProperty[],
   search: string,
 ): {
-  containers: OrganicStreamContainer[];
-  allContainers: OrganicStreamContainer[];
-  filteredContainers: OrganicStreamContainer[];
+  containers: Container[];
+  allContainers: Container[];
+  filteredContainers: Container[];
 } {
-  // TODO(WRAP-308): filter by scheme once the new API response is available
-  const allContainers = [
-    ...la.dryStreams.flatMap((scheme) => scheme.containers),
-    ...la.organicStreams.flatMap((scheme) => scheme.containers),
-  ];
+  const allContainers = property.flatMap((scheme) => scheme.containers);
 
   const filteredContainers = search
     ? allContainers.filter((container) =>
-        container.materials.some(
+        container.materials?.some(
           (material) => material.name.toLowerCase() === search.toLowerCase(),
         ),
       )
@@ -53,14 +49,14 @@ function useSearchResultType(
 }
 
 export default function ContainerList({
-  la,
+  property,
   search,
 }: {
-  readonly la: LocalAuthority;
+  readonly property: LocalAuthorityProperty[];
   readonly search: string;
 }) {
   const { t } = useTranslation();
-  const { containers, filteredContainers } = useContainers(la, search);
+  const { containers, filteredContainers } = useContainers(property, search);
   const filteredContainerCount = filteredContainers.length;
   const searchResultType = useSearchResultType(filteredContainerCount, search);
 

--- a/src/pages/[postcode]/home/ContainerList.tsx
+++ b/src/pages/[postcode]/home/ContainerList.tsx
@@ -106,13 +106,13 @@ export default function ContainerList({
                 <locator-container-name>
                   <h4>{containerName(container)}</h4>
                 </locator-container-name>
-                {container.cost && (
+                {container.cost ? (
                   <locator-container-subscription>
                     {t('components.container.subscription', {
                       cost: container.cost,
                     })}
                   </locator-container-subscription>
-                )}
+                ) : null}
                 {container.notes && (
                   <locator-container-notes>
                     {container.notes}

--- a/src/pages/[postcode]/home/collection.page.tsx
+++ b/src/pages/[postcode]/home/collection.page.tsx
@@ -1,7 +1,13 @@
 import { useSignal } from '@preact/signals';
-import { useEffect } from 'preact/hooks';
+import { useEffect, useRef } from 'preact/hooks';
 import { useTranslation } from 'react-i18next';
-import { Link, useParams, useSearchParams, Form } from 'react-router-dom';
+import {
+  Link,
+  useParams,
+  useSearchParams,
+  Form,
+  useLocation,
+} from 'react-router-dom';
 import '@etchteam/diamond-ui/canvas/Section/Section';
 import '@etchteam/diamond-ui/composition/Grid/Grid';
 import '@etchteam/diamond-ui/composition/Grid/GridItem';
@@ -16,6 +22,7 @@ import '@/components/content/HeaderTitle/HeaderTitle';
 import '@/components/content/Icon/Icon';
 
 import config from '@/config';
+import getPropertyDisplayName from '@/lib/getPropertyDisplayName';
 
 import ContainerList from './ContainerList';
 import { useHomeRecyclingLoaderData } from './home.loader';
@@ -24,14 +31,25 @@ export default function CollectionPage() {
   const { t } = useTranslation();
   const { postcode } = useParams();
   const { localAuthority, properties } = useHomeRecyclingLoaderData();
+  const location = useLocation();
   const [searchParams] = useSearchParams();
   const propertyType = searchParams.get('propertyType');
   const search = searchParams.get('search');
+  const propertyTypes = Object.keys(properties);
+  const property = properties[propertyType ?? propertyTypes[0]];
+  const menuOpen = useSignal(false);
   const submitting = useSignal(false);
+  const menuRef = useRef<HTMLDetailsElement>(null);
 
   useEffect(() => {
     submitting.value = false;
   }, [search]);
+
+  useEffect(() => {
+    // Force close the menu after navigation
+    menuRef.current?.removeAttribute('open');
+    menuOpen.value = false;
+  }, [location]);
 
   return (
     <locator-layout>
@@ -49,11 +67,45 @@ export default function CollectionPage() {
         </locator-header-title>
       </locator-header>
       <div slot="layout-main">
-        {propertyType && (
-          <locator-context-header>
-            <span className="diamond-text-weight-bold">{propertyType}</span>
-          </locator-context-header>
-        )}
+        <locator-context-header>
+          {propertyTypes.length > 1 ? (
+            <locator-details menu>
+              <details ref={menuRef}>
+                {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
+                <summary onClick={() => (menuOpen.value = !menuOpen.value)}>
+                  {menuOpen.value
+                    ? 'Collections in this area'
+                    : getPropertyDisplayName(property)}
+                  <locator-icon icon="expand" />
+                </summary>
+                <nav>
+                  <ul>
+                    {propertyTypes.map((type) => (
+                      <li key={type}>
+                        <Link
+                          to={`/${postcode}/home/collection?propertyType=${type}`}
+                        >
+                          <diamond-grid align-items="center" gap="xs">
+                            <diamond-grid-item grow shrink>
+                              {getPropertyDisplayName(properties[type])}
+                            </diamond-grid-item>
+                            <diamond-grid-item>
+                              <locator-icon icon="arrow-right" />
+                            </diamond-grid-item>
+                          </diamond-grid>
+                        </Link>
+                      </li>
+                    ))}
+                  </ul>
+                </nav>
+              </details>
+            </locator-details>
+          ) : (
+            <span className="diamond-text-weight-bold">
+              {getPropertyDisplayName(property)}
+            </span>
+          )}
+        </locator-context-header>
         <diamond-section padding="lg">
           <locator-wrap>
             <h3 id="bin-search-title" className="diamond-spacing-bottom-md">
@@ -71,10 +123,7 @@ export default function CollectionPage() {
               ></locator-material-search-input>
             </Form>
 
-            <ContainerList
-              property={properties[propertyType]}
-              search={search}
-            />
+            <ContainerList property={property} search={search} />
           </locator-wrap>
         </diamond-section>
       </div>

--- a/src/pages/[postcode]/home/collection.page.tsx
+++ b/src/pages/[postcode]/home/collection.page.tsx
@@ -23,12 +23,11 @@ import { useHomeRecyclingLoaderData } from './home.loader';
 export default function CollectionPage() {
   const { t } = useTranslation();
   const { postcode } = useParams();
-  const data = useHomeRecyclingLoaderData();
+  const { localAuthority, properties } = useHomeRecyclingLoaderData();
   const [searchParams] = useSearchParams();
-  const scheme = searchParams.get('scheme');
+  const propertyType = searchParams.get('propertyType');
   const search = searchParams.get('search');
   const submitting = useSignal(false);
-  const la = data?.localAuthority;
 
   useEffect(() => {
     submitting.value = false;
@@ -45,14 +44,14 @@ export default function CollectionPage() {
           </diamond-button>
           <div>
             <h2>{t('homeRecycling.collection.title')}</h2>
-            {la && <p>{la.name}</p>}
+            {localAuthority && <p>{localAuthority.name}</p>}
           </div>
         </locator-header-title>
       </locator-header>
       <div slot="layout-main">
-        {scheme && (
+        {propertyType && (
           <locator-context-header>
-            <span className="diamond-text-weight-bold">{scheme}</span>
+            <span className="diamond-text-weight-bold">{propertyType}</span>
           </locator-context-header>
         )}
         <diamond-section padding="lg">
@@ -62,7 +61,7 @@ export default function CollectionPage() {
             </h3>
 
             <Form method="get" onSubmit={() => (submitting.value = true)}>
-              <input type="hidden" name="scheme" value={scheme} />
+              <input type="hidden" name="propertyType" value={propertyType} />
               <locator-material-search-input
                 className="diamond-spacing-bottom-sm"
                 placeholder={t('components.materialSearchInput.placeholder')}
@@ -72,7 +71,10 @@ export default function CollectionPage() {
               ></locator-material-search-input>
             </Form>
 
-            <ContainerList la={la} search={search} />
+            <ContainerList
+              property={properties[propertyType]}
+              search={search}
+            />
           </locator-wrap>
         </diamond-section>
       </div>

--- a/src/pages/[postcode]/home/contact.page.tsx
+++ b/src/pages/[postcode]/home/contact.page.tsx
@@ -19,17 +19,17 @@ export default function HomeRecyclingPage() {
             <dt>{t(`${tContext}.website`)}</dt>
             <dd>
               <a
-                href={localAuthority.coreInformation.recyclingUri}
+                href={localAuthority.recyclingUri}
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                {localAuthority.coreInformation.recyclingUri}
+                {localAuthority.recyclingUri}
               </a>
             </dd>
           </div>
           <div>
             <dt>{t(`${tContext}.phone`)}</dt>
-            <dd>{localAuthority.coreInformation.enquiryNumber}</dd>
+            <dd>{localAuthority.enquiryNumber}</dd>
           </div>
           <div>
             <dt>{t(`${tContext}.notes.title`)}</dt>

--- a/src/pages/[postcode]/home/home.layout.tsx
+++ b/src/pages/[postcode]/home/home.layout.tsx
@@ -87,7 +87,7 @@ export default function HomeRecyclingLayout({
           {la && (
             <diamond-button width="full-width">
               <a
-                href={la.coreInformation.recyclingUri}
+                href={la.recyclingUri}
                 target="_blank"
                 rel="noopener noreferrer"
               >

--- a/src/pages/[postcode]/home/home.loader.ts
+++ b/src/pages/[postcode]/home/home.loader.ts
@@ -1,4 +1,4 @@
-import { omit } from 'lodash';
+import omit from 'lodash/omit';
 import { LoaderFunctionArgs, useRouteLoaderData } from 'react-router-dom';
 
 import LocatorApi from '@/lib/LocatorApi';

--- a/src/pages/[postcode]/home/home.loader.ts
+++ b/src/pages/[postcode]/home/home.loader.ts
@@ -1,10 +1,12 @@
+import { omit } from 'lodash';
 import { LoaderFunctionArgs, useRouteLoaderData } from 'react-router-dom';
 
 import LocatorApi from '@/lib/LocatorApi';
-import { LocalAuthority } from '@/types/locatorApi';
+import { LocalAuthority, PROPERTY_TYPE } from '@/types/locatorApi';
 
 export interface HomeRecyclingLoaderResponse {
   localAuthority: LocalAuthority;
+  properties: LocalAuthority['properties'];
 }
 
 export default async function homeRecyclingLoader({
@@ -14,9 +16,17 @@ export default async function homeRecyclingLoader({
   const localAuthority = await LocatorApi.get<LocalAuthority>(
     `local-authority/${postcode}`,
   );
+  const propertyTypes = Object.keys(localAuthority.properties);
 
   return {
     localAuthority,
+    // Place "All properties" at the end of the list
+    properties: propertyTypes.includes(PROPERTY_TYPE.ALL)
+      ? {
+          ...omit(localAuthority.properties, PROPERTY_TYPE.ALL),
+          [PROPERTY_TYPE.ALL]: localAuthority.properties[PROPERTY_TYPE.ALL],
+        }
+      : localAuthority.properties,
   };
 }
 

--- a/src/pages/[postcode]/home/home.page.tsx
+++ b/src/pages/[postcode]/home/home.page.tsx
@@ -1,10 +1,10 @@
-import uniqueId from 'lodash/uniqueId';
 import { useTranslation } from 'react-i18next';
 import { Link, useParams } from 'react-router-dom';
 import '@etchteam/diamond-ui/canvas/Card/Card';
 
-import containerName from '@/lib/containerName';
 import '@/components/content/Container/Container';
+import SchemeContainerSummary from '@/components/template/SchemeContainerSummary/SchemeContainerSummary';
+import getPropertyDisplayName from '@/lib/getPropertyDisplayName';
 
 import { useHomeRecyclingLoaderData } from './home.loader';
 
@@ -12,43 +12,28 @@ export default function HomeRecyclingPage() {
   const { t } = useTranslation();
   const { postcode } = useParams();
   const { localAuthority } = useHomeRecyclingLoaderData();
+  const propertyTypes = Object.keys(localAuthority.properties);
 
   return (
     <section className="diamond-spacing-bottom-lg">
       <h3>{t('homeRecycling.collections.title')}</h3>
       <p>{t('homeRecycling.collections.help')}</p>
-      {localAuthority.dryStreams.map((scheme) => {
-        // TODO (WRAP-309): separate schemes by property type once the api is in place
-        const safeSchemeName = encodeURIComponent(scheme.name);
+
+      {propertyTypes.map((propertyType) => {
+        const safePropertyType = encodeURIComponent(propertyType);
+        const property = localAuthority.properties[propertyType];
+        const containers = property.flatMap((scheme) => scheme.containers);
 
         return (
           <Link
-            to={`/${postcode}/home/collection?scheme=${safeSchemeName}`}
-            key={safeSchemeName}
+            to={`/${postcode}/home/collection?propertyType=${safePropertyType}`}
+            key={safePropertyType}
           >
-            <diamond-card border radius>
-              <h4 className="diamond-spacing-bottom-md">{scheme.name}</h4>
-              <ul role="list" className="list-style-none">
-                {scheme.containers.map((container) => (
-                  <li
-                    key={uniqueId(container.name)}
-                    className="diamond-spacing-bottom-sm"
-                  >
-                    <locator-container>
-                      <locator-container-svg
-                        name={container.name}
-                        body-colour={container.bodyColour}
-                        lid-colour={container.lidColour}
-                      />
-                      <locator-container-content>
-                        <locator-container-name>
-                          {containerName(container)}
-                        </locator-container-name>
-                      </locator-container-content>
-                    </locator-container>
-                  </li>
-                ))}
-              </ul>
+            <diamond-card className="diamond-spacing-bottom-md" border radius>
+              <h4 className="diamond-spacing-bottom-md">
+                {getPropertyDisplayName(property)}
+              </h4>
+              <SchemeContainerSummary containers={containers} limit={3} />
             </diamond-card>
           </Link>
         );

--- a/src/pages/[postcode]/home/home.page.tsx
+++ b/src/pages/[postcode]/home/home.page.tsx
@@ -11,8 +11,8 @@ import { useHomeRecyclingLoaderData } from './home.loader';
 export default function HomeRecyclingPage() {
   const { t } = useTranslation();
   const { postcode } = useParams();
-  const { localAuthority } = useHomeRecyclingLoaderData();
-  const propertyTypes = Object.keys(localAuthority.properties);
+  const { properties } = useHomeRecyclingLoaderData();
+  const propertyTypes = Object.keys(properties);
 
   return (
     <section className="diamond-spacing-bottom-lg">
@@ -21,7 +21,7 @@ export default function HomeRecyclingPage() {
 
       {propertyTypes.map((propertyType) => {
         const safePropertyType = encodeURIComponent(propertyType);
-        const property = localAuthority.properties[propertyType];
+        const property = properties[propertyType];
         const containers = property.flatMap((scheme) => scheme.containers);
 
         return (

--- a/src/pages/[postcode]/material/RecycleAtHome.tsx
+++ b/src/pages/[postcode]/material/RecycleAtHome.tsx
@@ -12,7 +12,7 @@ import '@/components/control/IconLink/IconLink';
 import '@/components/content/Icon/Icon';
 import '@/components/content/Container/Container';
 
-import containerName from '@/lib/containerName';
+import SchemeContainerSummary from '@/components/template/SchemeContainerSummary/SchemeContainerSummary';
 import getPropertyDisplayName from '@/lib/getPropertyDisplayName';
 import {
   LocalAuthority,
@@ -84,45 +84,20 @@ function OneProperty({
   readonly property: LocalAuthorityProperty[];
 }) {
   const { t } = useTranslation();
-  const tContext = 'material.recycleAtHome.oneProperty';
   const containers = property
     .flatMap((scheme) => scheme.containers)
     .filter((container) =>
       container.materials?.some((material) => material.id === materialId),
     );
-  const firstTwoContainers = containers.slice(0, 2);
-  const remainingContainers = containers.slice(2);
 
   return (
     <>
       <p className="diamond-text-size-sm">
-        {t(`${tContext}.collection`, { count: containers.length })}
+        {t('material.recycleAtHome.oneProperty.collection', {
+          count: containers.length,
+        })}
       </p>
-      <ul role="list" className="list-style-none diamond-spacing-bottom-md">
-        {firstTwoContainers.map((container) => (
-          <li key={container.name} className="diamond-spacing-bottom-sm">
-            <locator-container>
-              <locator-container-svg
-                name={container.name}
-                body-colour={container.bodyColour}
-                lid-colour={container.lidColour}
-              />
-              <locator-container-content>
-                <locator-container-name>
-                  {containerName(container)}
-                </locator-container-name>
-              </locator-container-content>
-            </locator-container>
-          </li>
-        ))}
-        {remainingContainers.length > 0 && (
-          <li>
-            {t(`${tContext}.otherContainers`, {
-              count: remainingContainers.length,
-            })}
-          </li>
-        )}
-      </ul>
+      <SchemeContainerSummary containers={containers} />
     </>
   );
 }

--- a/src/pages/[postcode]/material/RecycleAtHome.tsx
+++ b/src/pages/[postcode]/material/RecycleAtHome.tsx
@@ -115,7 +115,7 @@ export default function RecycleAtHome({
   const { t } = useTranslation();
   const allPropertyTypes = Object.keys(allProperties);
   const propertyTypesCollectingThisMaterial = Object.keys(
-    propertiesCollectingThisMaterial,
+    propertiesCollectingThisMaterial ?? {},
   );
   let type: 'oneProperty' | 'noProperties' | 'manyProperties' = 'noProperties';
 

--- a/src/pages/[postcode]/material/material.loader.ts
+++ b/src/pages/[postcode]/material/material.loader.ts
@@ -9,7 +9,7 @@ import {
 
 export interface MaterialLoaderResponse {
   materialId: number;
-  home: LocalAuthority;
+  localAuthority: LocalAuthority;
   locations: Location[];
 }
 
@@ -20,7 +20,7 @@ async function getData({
   const url = new URL(request.url);
   const materialId = Number(url.searchParams.get('id'));
   const postcode = params.postcode;
-  const home = await LocatorApi.get<LocalAuthority>(
+  const localAuthority = await LocatorApi.get<LocalAuthority>(
     `local-authority/${postcode}`,
   );
   const locations = await LocatorApi.get<LocationsResponse>(
@@ -28,7 +28,7 @@ async function getData({
   );
 
   return {
-    home,
+    localAuthority,
     materialId,
     locations: locations.items,
   };

--- a/src/pages/[postcode]/material/material.page.tsx
+++ b/src/pages/[postcode]/material/material.page.tsx
@@ -8,7 +8,7 @@ import '@/components/content/Icon/Icon';
 import '@/components/canvas/LoadingCard/LoadingCard';
 import '@/components/canvas/Hero/Hero';
 import '@/components/composition/Wrap/Wrap';
-import getDryContainersByMaterial from '@/lib/getDryContainersByMaterial';
+import getPropertiesByMaterial from '@/lib/getPropertiesByMaterial';
 
 import NearbyPlaces from './NearbyPlaces';
 import RecycleAtHome from './RecycleAtHome';
@@ -35,12 +35,13 @@ function Loading() {
 
 function MaterialPageContent() {
   const { t } = useTranslation();
-  const { home, locations, materialId } =
+  const { localAuthority, locations, materialId } =
     useAsyncValue() as MaterialLoaderResponse;
-  const schemes = getDryContainersByMaterial(materialId, home.dryStreams);
-  const recyclableAtHome = schemes.some(
-    (scheme) => scheme.containers.length > 0,
+  const propertiesCollectingThisMaterial = getPropertiesByMaterial(
+    materialId,
+    localAuthority.properties,
   );
+  const recyclableAtHome = propertiesCollectingThisMaterial !== undefined;
   const recyclableNearby = locations.length > 0;
   const recyclable = recyclableAtHome || recyclableNearby;
 
@@ -55,7 +56,13 @@ function MaterialPageContent() {
       <diamond-enter type="fade-in-up" delay={0.25}>
         <locator-wrap>
           <section className="diamond-spacing-bottom-lg">
-            <RecycleAtHome schemes={schemes} />
+            <RecycleAtHome
+              materialId={materialId}
+              allProperties={localAuthority.properties}
+              propertiesCollectingThisMaterial={
+                propertiesCollectingThisMaterial
+              }
+            />
           </section>
           <section className="diamond-spacing-bottom-lg">
             <NearbyPlaces locations={locations} />

--- a/src/types/locatorApi.ts
+++ b/src/types/locatorApi.ts
@@ -25,13 +25,6 @@ export interface MaterialWithCategory extends Material {
   category: MaterialCategory;
 }
 
-export interface CoreInformation {
-  enquiryNumber: string;
-  recyclingUri: string;
-  hwrcUri: string;
-  gardenWasteUri: string;
-}
-
 export type ContainerName =
   | 'Box'
   | 'Communal Wheeled Bin'
@@ -52,34 +45,33 @@ export interface Container {
   interiorColour?: string;
   notes?: string;
   materials?: MaterialWithCategory[];
-}
-
-export interface OrganicStreamContainer extends Container {
   cost?: number;
 }
 
-export interface ResidualScheme {
-  name: string;
-  containers: Container[];
+export enum PROPERTY_TYPE {
+  ALL = 'All properties',
+  KERBSIDE = 'Kerbside properties',
+  FLATS_WITH_COMMUNAL_BINS = 'Flats with communal bins',
+  FLATS_WITH_INDIVIDUAL_BINS = 'Flats with individual bins or bags',
+  NARROW_ACCESS = 'Narrow access/difficult to reach/remote properties',
 }
 
-export interface OrganicScheme {
+export interface LocalAuthorityProperty {
   name: string;
-  containers: OrganicStreamContainer[];
-}
-
-export interface DryScheme {
-  name: string;
+  type: 'Dry' | 'Food' | 'Garden' | 'Residual';
   containers: Container[];
+  notes?: string[];
 }
 
 export interface LocalAuthority {
   id: number;
   name: string;
-  coreInformation: CoreInformation;
-  dryStreams: DryScheme[];
-  organicStreams: OrganicScheme[];
-  residualStreams: ResidualScheme[];
+  lastUpdate: string;
+  enquiryNumber: string;
+  recyclingUri: string;
+  hwrcUri: string;
+  gardenWasteUri: string;
+  properties: { [key in PROPERTY_TYPE]?: LocalAuthorityProperty[] };
 }
 
 export interface Location {

--- a/stylelint.config.cjs
+++ b/stylelint.config.cjs
@@ -7,5 +7,11 @@ module.exports = {
         ignore: ['attribute'],
       },
     ],
+    'selector-max-compound-selectors': [
+      5,
+      {
+        severity: 'warning',
+      },
+    ],
   },
 };

--- a/tests/end-to-end/material.test.ts
+++ b/tests/end-to-end/material.test.ts
@@ -8,7 +8,7 @@ import {
 } from '../mocks/localAuthority';
 import { LOCATIONS_ENDPOINT, LocationsResponse } from '../mocks/locations';
 import describeEndToEndTest from '../utils/describeEndToEndTest';
-import { DryScheme } from '@/types/locatorApi';
+import { PROPERTY_TYPE } from '@/types/locatorApi';
 
 describeEndToEndTest('Material page', () => {
   test('Single scheme + location options', async ({ page, widget }) => {
@@ -22,7 +22,9 @@ describeEndToEndTest('Material page', () => {
 
     const recyclableText = page.getByText(t('material.hero.yes')).first();
     const homeText = page
-      .getByText(t('material.recycleAtHome.oneScheme.collection', { count: 1 }))
+      .getByText(
+        t('material.recycleAtHome.oneProperty.collection', { count: 1 }),
+      )
       .first();
     const locationsText = page
       .getByText(t('material.nearbyPlaces.places.title'))
@@ -43,23 +45,42 @@ describeEndToEndTest('Material page', () => {
   });
 
   test('Some home recycling options', async ({ page, widget }) => {
+    const mockedLaResponse = {
+      ...LocalAuthorityResponse,
+      properties: {
+        ...LocalAuthorityResponse.properties,
+        [PROPERTY_TYPE.NARROW_ACCESS]: [
+          {
+            name: 'Fake scheme',
+            type: 'Dry',
+            containers: [
+              {
+                name: 'Box',
+                displayName: 'Box (35 to 60L)',
+                bodyColour: '#4f4f4f',
+                lidColour: '#4f4f4f',
+                notes: ['containers can be black or green.'],
+                materials: [
+                  {
+                    id: 1000,
+                    name: 'Fake material',
+                    popular: false,
+                    category: {
+                      id: 7,
+                      name: 'Plastic bottles',
+                      popular: false,
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    };
+
     await page.route(LOCAL_AUTHORITY_ENDPOINT, (route) => {
-      const dryStreams = LocalAuthorityResponse.dryStreams.concat([
-        {
-          name: 'Fake scheme 1',
-          containers: [],
-        },
-        {
-          name: 'Fake scheme 2',
-          containers: [],
-        },
-      ]);
-      route.fulfill({
-        json: {
-          ...LocalAuthorityResponse,
-          dryStreams,
-        },
-      });
+      route.fulfill({ json: mockedLaResponse });
     });
 
     await page.route(LOCATIONS_ENDPOINT, (route) => {
@@ -68,7 +89,9 @@ describeEndToEndTest('Material page', () => {
 
     const recyclableText = page.getByText(t('material.hero.yes')).first();
     const schemeOneText = page
-      .getByText(LocalAuthorityResponse.dryStreams[0].name)
+      .getByText(
+        mockedLaResponse.properties[PROPERTY_TYPE.NARROW_ACCESS][0].name,
+      )
       .first();
     const somePropertiesText = page.getByText('some properties').first();
     const locationsText = page
@@ -91,45 +114,42 @@ describeEndToEndTest('Material page', () => {
   });
 
   test('All home recycling options', async ({ page, widget }) => {
+    const mockedLaResponse = {
+      ...LocalAuthorityResponse,
+      properties: {
+        ...LocalAuthorityResponse.properties,
+        [PROPERTY_TYPE.NARROW_ACCESS]: [
+          {
+            name: 'Fake scheme',
+            type: 'Dry',
+            containers: [
+              {
+                name: 'Box',
+                displayName: 'Box (35 to 60L)',
+                bodyColour: '#4f4f4f',
+                lidColour: '#4f4f4f',
+                notes: ['containers can be black or green.'],
+                materials: [
+                  {
+                    id: 43,
+                    name: 'Plastic milk bottles',
+                    popular: false,
+                    category: {
+                      id: 7,
+                      name: 'Plastic bottles',
+                      popular: false,
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    };
+
     await page.route(LOCAL_AUTHORITY_ENDPOINT, (route) => {
-      const dryStreams = LocalAuthorityResponse.dryStreams.concat([
-        {
-          name: 'Fake scheme 1',
-          containers: [
-            {
-              name: 'Box',
-              displayName: 'Box (35 to 60L)',
-              materials: [
-                {
-                  id: 43,
-                  name: 'Plastic milk bottles',
-                },
-              ],
-            },
-          ],
-        },
-        {
-          name: 'Fake scheme 2',
-          containers: [
-            {
-              name: 'Box',
-              displayName: 'Box (35 to 60L)',
-              materials: [
-                {
-                  id: 43,
-                  name: 'Plastic milk bottles',
-                },
-              ],
-            },
-          ],
-        },
-      ] as DryScheme[]);
-      route.fulfill({
-        json: {
-          ...LocalAuthorityResponse,
-          dryStreams,
-        },
-      });
+      route.fulfill({ json: mockedLaResponse });
     });
 
     await page.route(LOCATIONS_ENDPOINT, (route) => {
@@ -138,7 +158,9 @@ describeEndToEndTest('Material page', () => {
 
     const recyclableText = page.getByText(t('material.hero.yes')).first();
     const schemeOneText = page
-      .getByText(LocalAuthorityResponse.dryStreams[0].name)
+      .getByText(
+        mockedLaResponse.properties[PROPERTY_TYPE.NARROW_ACCESS][0].name,
+      )
       .first();
     const somePropertiesText = page.getByText('all properties').first();
     const locationsText = page
@@ -171,7 +193,7 @@ describeEndToEndTest('Material page', () => {
 
     const recyclableText = page.getByText(t('material.hero.yes')).first();
     const homeText = page
-      .getByText(t('material.recycleAtHome.noSchemes.content'))
+      .getByText(t('material.recycleAtHome.noProperties.content'))
       .first();
     const locationsText = page
       .getByText(t('material.nearbyPlaces.places.title'))
@@ -199,7 +221,7 @@ describeEndToEndTest('Material page', () => {
 
     const recyclableText = page.getByText(t('material.hero.no')).first();
     const homeText = page
-      .getByText(t('material.recycleAtHome.noSchemes.content'))
+      .getByText(t('material.recycleAtHome.noProperties.content'))
       .first();
     const locationsText = page
       .getByText(t('material.nearbyPlaces.noPlaces.title'))

--- a/tests/mocks/localAuthority.ts
+++ b/tests/mocks/localAuthority.ts
@@ -3,881 +3,1489 @@ import { LocalAuthority } from '@/types/locatorApi';
 
 export const LOCAL_AUTHORITY_ENDPOINT = `${config.locatorApiPath}local-authority/**`;
 
-export const LocalAuthorityResponse: LocalAuthority = {
+export const localAuthority: LocalAuthority = {
   id: 321,
   name: 'North Devon District Council',
-  coreInformation: {
-    enquiryNumber: '01271 374776',
-    recyclingUri:
-      'https://www.northdevon.gov.uk/bins-and-recycling/what-goes-in-your-bin-box-or-bag',
-    hwrcUri:
-      'https://new.devon.gov.uk/wasteandrecycling/centre/seven-brethren/',
-    gardenWasteUri:
-      'https://www.northdevon.gov.uk/bins-and-recycling/garden-waste-green-wheelie-bin-collections',
-  },
-  dryStreams: [
-    {
-      name: 'All properties',
-      containers: [
-        {
-          name: 'Reusable Sack',
-          displayName: 'Reusable Sack',
-          bodyColour: '#3cb848',
-          lidColour: null,
-          notes: null,
-          materials: [
-            {
-              id: 10,
-              name: 'Junk mail',
-              popular: false,
-              category: {
+  lastUpdate: '2024-02-07T15:47:56.064Z',
+  enquiryNumber: '01271 374776',
+  recyclingUri:
+    'https://www.northdevon.gov.uk/bins-and-recycling/what-goes-in-your-bin-box-or-bag',
+  hwrcUri: 'https://new.devon.gov.uk/wasteandrecycling/centre/seven-brethren/',
+  gardenWasteUri:
+    'https://www.northdevon.gov.uk/bins-and-recycling/garden-waste-green-wheelie-bin-collections',
+  properties: {
+    'All properties': [
+      {
+        name: 'All properties',
+        type: 'Dry',
+        containers: [
+          {
+            name: 'Reusable Sack',
+            displayName: 'Reusable Sack',
+            bodyColour: '#3cb848',
+            lidColour: null,
+            notes: [],
+            materials: [
+              {
+                id: 10,
+                name: 'Junk mail',
+                popular: false,
+                category: {
+                  id: 2,
+                  name: 'Paper',
+                  popular: false,
+                },
+              },
+              {
+                id: 11,
+                name: 'Magazines',
+                popular: false,
+                category: {
+                  id: 2,
+                  name: 'Paper',
+                  popular: false,
+                },
+              },
+              {
+                id: 12,
+                name: 'Newspapers',
+                popular: false,
+                category: {
+                  id: 2,
+                  name: 'Paper',
+                  popular: false,
+                },
+              },
+              {
+                id: 13,
+                name: 'Shredded paper',
+                popular: false,
+                category: {
+                  id: 2,
+                  name: 'Paper',
+                  popular: false,
+                },
+              },
+              {
+                id: 14,
+                name: 'Telephone directories',
+                popular: false,
+                category: {
+                  id: 2,
+                  name: 'Paper',
+                  popular: false,
+                },
+              },
+              {
+                id: 15,
+                name: 'Window envelopes',
+                popular: false,
+                category: {
+                  id: 2,
+                  name: 'Paper',
+                  popular: false,
+                },
+              },
+              {
+                id: 52,
+                name: 'Clothing',
+                popular: true,
+                category: {
+                  id: 9,
+                  name: 'Textiles',
+                  popular: false,
+                },
+              },
+              {
+                id: 54,
+                name: 'Shoes & bags',
+                popular: false,
+                category: {
+                  id: 9,
+                  name: 'Textiles',
+                  popular: false,
+                },
+              },
+            ],
+          },
+          {
+            name: 'Box',
+            displayName: 'Box (35 to 60L)',
+            bodyColour: '#4f4f4f',
+            lidColour: '#4f4f4f',
+            notes: ['containers can be black or green.'],
+            materials: [
+              {
+                id: 18,
+                name: 'Aluminium foil',
+                popular: false,
+                category: {
+                  id: 3,
+                  name: 'Foil',
+                  popular: false,
+                },
+              },
+              {
+                id: 19,
+                name: 'Foil trays',
+                popular: false,
+                category: {
+                  id: 3,
+                  name: 'Foil',
+                  popular: false,
+                },
+              },
+              {
+                id: 23,
+                name: 'Aerosols',
+                popular: false,
+                category: {
+                  id: 5,
+                  name: 'Metal',
+                  popular: false,
+                },
+              },
+              {
+                id: 24,
+                name: 'Drinks cans',
+                popular: false,
+                category: {
+                  id: 5,
+                  name: 'Metal',
+                  popular: false,
+                },
+              },
+              {
+                id: 25,
+                name: 'Food tins',
+                popular: false,
+                category: {
+                  id: 5,
+                  name: 'Metal',
+                  popular: false,
+                },
+              },
+              {
+                id: 26,
+                name: 'Metal lids from glass jars',
+                popular: false,
+                category: {
+                  id: 5,
+                  name: 'Metal',
+                  popular: false,
+                },
+              },
+              {
+                id: 42,
+                name: 'Household cleaner & detergent bottles',
+                popular: false,
+                category: {
+                  id: 7,
+                  name: 'Plastic bottles',
+                  popular: false,
+                },
+              },
+              {
+                id: 43,
+                name: 'Plastic milk bottles',
+                popular: false,
+                category: {
+                  id: 7,
+                  name: 'Plastic bottles',
+                  popular: false,
+                },
+              },
+              {
+                id: 44,
+                name: 'Plastic drinks bottles',
+                popular: false,
+                category: {
+                  id: 7,
+                  name: 'Plastic bottles',
+                  popular: false,
+                },
+              },
+              {
+                id: 45,
+                name: 'Toiletries & shampoo bottles',
+                popular: false,
+                category: {
+                  id: 7,
+                  name: 'Plastic bottles',
+                  popular: false,
+                },
+              },
+              {
+                id: 47,
+                name: 'Food pots & tubs',
+                popular: false,
+                category: {
+                  id: 8,
+                  name: 'Plastic packaging',
+                  popular: false,
+                },
+              },
+              {
+                id: 48,
+                name: 'Margarine tubs',
+                popular: false,
+                category: {
+                  id: 8,
+                  name: 'Plastic packaging',
+                  popular: false,
+                },
+              },
+              {
+                id: 50,
+                name: 'Plastic trays',
+                popular: false,
+                category: {
+                  id: 8,
+                  name: 'Plastic packaging',
+                  popular: false,
+                },
+              },
+              {
+                id: 51,
+                name: 'Yoghurt pots',
+                popular: false,
+                category: {
+                  id: 8,
+                  name: 'Plastic packaging',
+                  popular: false,
+                },
+              },
+              {
+                id: 58,
+                name: 'Laptops',
+                popular: false,
+                category: {
+                  id: 10,
+                  name: 'Electricals',
+                  popular: false,
+                },
+              },
+              {
+                id: 59,
+                name: 'Computers',
+                popular: false,
+                category: {
+                  id: 10,
+                  name: 'Electricals',
+                  popular: false,
+                },
+              },
+              {
+                id: 60,
+                name: 'TVs',
+                popular: false,
+                category: {
+                  id: 10,
+                  name: 'Electricals',
+                  popular: false,
+                },
+              },
+              {
+                id: 61,
+                name: 'DVD/CD players',
+                popular: false,
+                category: {
+                  id: 10,
+                  name: 'Electricals',
+                  popular: false,
+                },
+              },
+              {
+                id: 62,
+                name: 'Hi-fi',
+                popular: false,
+                category: {
+                  id: 10,
+                  name: 'Electricals',
+                  popular: false,
+                },
+              },
+              {
+                id: 63,
+                name: 'Telephones/fax',
+                popular: false,
+                category: {
+                  id: 10,
+                  name: 'Electricals',
+                  popular: false,
+                },
+              },
+              {
+                id: 64,
+                name: 'Mobile phones',
+                popular: true,
+                category: {
+                  id: 10,
+                  name: 'Electricals',
+                  popular: false,
+                },
+              },
+              {
+                id: 65,
+                name: 'Cameras',
+                popular: false,
+                category: {
+                  id: 10,
+                  name: 'Electricals',
+                  popular: false,
+                },
+              },
+              {
+                id: 67,
+                name: 'Hairdryers & electric toothbrushes',
+                popular: false,
+                category: {
+                  id: 10,
+                  name: 'Electricals',
+                  popular: false,
+                },
+              },
+              {
+                id: 69,
+                name: 'Electronic toys & games',
+                popular: false,
+                category: {
+                  id: 10,
+                  name: 'Electricals',
+                  popular: false,
+                },
+              },
+              {
+                id: 70,
+                name: 'Energy-saving light bulbs',
+                popular: false,
+                category: {
+                  id: 10,
+                  name: 'Electricals',
+                  popular: false,
+                },
+              },
+              {
+                id: 71,
+                name: 'Microwave',
+                popular: false,
+                category: {
+                  id: 10,
+                  name: 'Electricals',
+                  popular: false,
+                },
+              },
+              {
+                id: 72,
+                name: 'Table lamps',
+                popular: false,
+                category: {
+                  id: 10,
+                  name: 'Electricals',
+                  popular: false,
+                },
+              },
+              {
+                id: 106,
+                name: 'Set top boxes',
+                popular: false,
+                category: {
+                  id: 10,
+                  name: 'Electricals',
+                  popular: false,
+                },
+              },
+              {
+                id: 107,
+                name: 'Routers',
+                popular: false,
+                category: {
+                  id: 10,
+                  name: 'Electricals',
+                  popular: false,
+                },
+              },
+            ],
+          },
+          {
+            name: 'Reusable Sack',
+            displayName: 'Reusable Sack',
+            bodyColour: '#ad7849',
+            lidColour: null,
+            notes: [],
+            materials: [
+              {
+                id: 1,
+                name: 'Cardboard egg boxes',
+                popular: false,
+                category: {
+                  id: 1,
+                  name: 'Cardboard',
+                  popular: false,
+                },
+              },
+              {
                 id: 2,
-                name: 'Paper',
+                name: 'Cardboard fruit and veg punnets',
                 popular: false,
+                category: {
+                  id: 1,
+                  name: 'Cardboard',
+                  popular: false,
+                },
               },
-            },
-            {
-              id: 11,
-              name: 'Magazines',
-              popular: false,
-              category: {
-                id: 2,
-                name: 'Paper',
-                popular: false,
-              },
-            },
-            {
-              id: 12,
-              name: 'Newspapers',
-              popular: false,
-              category: {
-                id: 2,
-                name: 'Paper',
-                popular: false,
-              },
-            },
-            {
-              id: 13,
-              name: 'Shredded paper',
-              popular: false,
-              category: {
-                id: 2,
-                name: 'Paper',
-                popular: false,
-              },
-            },
-            {
-              id: 14,
-              name: 'Telephone directories',
-              popular: false,
-              category: {
-                id: 2,
-                name: 'Paper',
-                popular: false,
-              },
-            },
-            {
-              id: 15,
-              name: 'Window envelopes',
-              popular: false,
-              category: {
-                id: 2,
-                name: 'Paper',
-                popular: false,
-              },
-            },
-            {
-              id: 52,
-              name: 'Clothing',
-              popular: true,
-              category: {
-                id: 9,
-                name: 'Textiles',
-                popular: false,
-              },
-            },
-            {
-              id: 54,
-              name: 'Shoes & bags',
-              popular: false,
-              category: {
-                id: 9,
-                name: 'Textiles',
-                popular: false,
-              },
-            },
-          ],
-        },
-        {
-          name: 'Box',
-          displayName: 'Box (35 to 60L)',
-          bodyColour: '#4f4f4f',
-          lidColour: '#4f4f4f',
-          notes: 'containers can be black or green.',
-          materials: [
-            {
-              id: 18,
-              name: 'Aluminium foil',
-              popular: false,
-              category: {
+              {
                 id: 3,
-                name: 'Foil',
+                name: 'Cardboard sleeves',
                 popular: false,
+                category: {
+                  id: 1,
+                  name: 'Cardboard',
+                  popular: false,
+                },
               },
-            },
-            {
-              id: 19,
-              name: 'Foil trays',
-              popular: false,
-              category: {
-                id: 3,
-                name: 'Foil',
-                popular: false,
-              },
-            },
-            {
-              id: 23,
-              name: 'Aerosols',
-              popular: false,
-              category: {
-                id: 5,
-                name: 'Metal',
-                popular: false,
-              },
-            },
-            {
-              id: 24,
-              name: 'Drinks cans',
-              popular: false,
-              category: {
-                id: 5,
-                name: 'Metal',
-                popular: false,
-              },
-            },
-            {
-              id: 25,
-              name: 'Food tins',
-              popular: false,
-              category: {
-                id: 5,
-                name: 'Metal',
-                popular: false,
-              },
-            },
-            {
-              id: 26,
-              name: 'Metal lids from glass jars',
-              popular: false,
-              category: {
-                id: 5,
-                name: 'Metal',
-                popular: false,
-              },
-            },
-            {
-              id: 42,
-              name: 'Household cleaner & detergent bottles',
-              popular: false,
-              category: {
-                id: 7,
-                name: 'Plastic bottles',
-                popular: false,
-              },
-            },
-            {
-              id: 43,
-              name: 'Plastic milk bottles',
-              popular: false,
-              category: {
-                id: 7,
-                name: 'Plastic bottles',
-                popular: false,
-              },
-            },
-            {
-              id: 44,
-              name: 'Plastic drinks bottles',
-              popular: false,
-              category: {
-                id: 7,
-                name: 'Plastic bottles',
-                popular: false,
-              },
-            },
-            {
-              id: 45,
-              name: 'Toiletries & shampoo bottles',
-              popular: false,
-              category: {
-                id: 7,
-                name: 'Plastic bottles',
-                popular: false,
-              },
-            },
-            {
-              id: 47,
-              name: 'Food pots & tubs',
-              popular: false,
-              category: {
-                id: 8,
-                name: 'Plastic packaging',
-                popular: false,
-              },
-            },
-            {
-              id: 48,
-              name: 'Margarine tubs',
-              popular: false,
-              category: {
-                id: 8,
-                name: 'Plastic packaging',
-                popular: false,
-              },
-            },
-            {
-              id: 50,
-              name: 'Plastic trays',
-              popular: false,
-              category: {
-                id: 8,
-                name: 'Plastic packaging',
-                popular: false,
-              },
-            },
-            {
-              id: 51,
-              name: 'Yoghurt pots',
-              popular: false,
-              category: {
-                id: 8,
-                name: 'Plastic packaging',
-                popular: false,
-              },
-            },
-            {
-              id: 58,
-              name: 'Laptops',
-              popular: false,
-              category: {
-                id: 10,
-                name: 'Electricals',
-                popular: false,
-              },
-            },
-            {
-              id: 59,
-              name: 'Computers',
-              popular: false,
-              category: {
-                id: 10,
-                name: 'Electricals',
-                popular: false,
-              },
-            },
-            {
-              id: 60,
-              name: 'TVs',
-              popular: false,
-              category: {
-                id: 10,
-                name: 'Electricals',
-                popular: false,
-              },
-            },
-            {
-              id: 61,
-              name: 'DVD/CD players',
-              popular: false,
-              category: {
-                id: 10,
-                name: 'Electricals',
-                popular: false,
-              },
-            },
-            {
-              id: 62,
-              name: 'Hi-fi',
-              popular: false,
-              category: {
-                id: 10,
-                name: 'Electricals',
-                popular: false,
-              },
-            },
-            {
-              id: 63,
-              name: 'Telephones/fax',
-              popular: false,
-              category: {
-                id: 10,
-                name: 'Electricals',
-                popular: false,
-              },
-            },
-            {
-              id: 64,
-              name: 'Mobile phones',
-              popular: true,
-              category: {
-                id: 10,
-                name: 'Electricals',
-                popular: false,
-              },
-            },
-            {
-              id: 65,
-              name: 'Cameras',
-              popular: false,
-              category: {
-                id: 10,
-                name: 'Electricals',
-                popular: false,
-              },
-            },
-            {
-              id: 67,
-              name: 'Hairdryers & electric toothbrushes',
-              popular: false,
-              category: {
-                id: 10,
-                name: 'Electricals',
-                popular: false,
-              },
-            },
-            {
-              id: 69,
-              name: 'Electronic toys & games',
-              popular: false,
-              category: {
-                id: 10,
-                name: 'Electricals',
-                popular: false,
-              },
-            },
-            {
-              id: 70,
-              name: 'Energy-saving light bulbs',
-              popular: false,
-              category: {
-                id: 10,
-                name: 'Electricals',
-                popular: false,
-              },
-            },
-            {
-              id: 71,
-              name: 'Microwave',
-              popular: false,
-              category: {
-                id: 10,
-                name: 'Electricals',
-                popular: false,
-              },
-            },
-            {
-              id: 72,
-              name: 'Table lamps',
-              popular: false,
-              category: {
-                id: 10,
-                name: 'Electricals',
-                popular: false,
-              },
-            },
-            {
-              id: 106,
-              name: 'Set top boxes',
-              popular: false,
-              category: {
-                id: 10,
-                name: 'Electricals',
-                popular: false,
-              },
-            },
-            {
-              id: 107,
-              name: 'Routers',
-              popular: false,
-              category: {
-                id: 10,
-                name: 'Electricals',
-                popular: false,
-              },
-            },
-          ],
-        },
-        {
-          name: 'Reusable Sack',
-          displayName: 'Reusable Sack',
-          bodyColour: '#ad7849',
-          lidColour: null,
-          notes: null,
-          materials: [
-            {
-              id: 1,
-              name: 'Cardboard egg boxes',
-              popular: false,
-              category: {
-                id: 1,
-                name: 'Cardboard',
-                popular: false,
-              },
-            },
-            {
-              id: 2,
-              name: 'Cardboard fruit and veg punnets',
-              popular: false,
-              category: {
-                id: 1,
-                name: 'Cardboard',
-                popular: false,
-              },
-            },
-            {
-              id: 3,
-              name: 'Cardboard sleeves',
-              popular: false,
-              category: {
-                id: 1,
-                name: 'Cardboard',
-                popular: false,
-              },
-            },
-            {
-              id: 4,
-              name: 'Cereal boxes',
-              popular: false,
-              category: {
-                id: 1,
-                name: 'Cardboard',
-                popular: false,
-              },
-            },
-            {
-              id: 5,
-              name: 'Corrugated cardboard',
-              popular: false,
-              category: {
-                id: 1,
-                name: 'Cardboard',
-                popular: false,
-              },
-            },
-            {
-              id: 7,
-              name: 'Toilet roll tubes',
-              popular: false,
-              category: {
-                id: 1,
-                name: 'Cardboard',
-                popular: false,
-              },
-            },
-          ],
-        },
-        {
-          name: 'Box',
-          displayName: 'Box (35 to 60L)',
-          bodyColour: '#2d9cdb',
-          lidColour: null,
-          notes: null,
-          materials: [
-            {
-              id: 20,
-              name: 'Glass bottles and jars',
-              popular: true,
-              category: {
+              {
                 id: 4,
-                name: 'Glass',
+                name: 'Cereal boxes',
                 popular: false,
+                category: {
+                  id: 1,
+                  name: 'Cardboard',
+                  popular: false,
+                },
               },
-            },
-          ],
-        },
-      ],
-    },
-  ],
-  organicStreams: [
-    {
-      name: 'All kerbside properties',
-      containers: [
-        {
-          name: 'Kerbside Caddy',
-          displayName: 'Kerbside Caddy (23L)',
-          bodyColour: '#3cb848',
-          lidColour: null,
-          notes:
-            'Any bag accepted, bread bags, carrier bags, black bags, cereal bags.',
-          materials: [
-            {
-              id: 93,
-              name: 'Bread',
-              popular: false,
-              category: {
-                id: 15,
-                name: 'Food waste',
+              {
+                id: 5,
+                name: 'Corrugated cardboard',
                 popular: false,
+                category: {
+                  id: 1,
+                  name: 'Cardboard',
+                  popular: false,
+                },
               },
-            },
-            {
-              id: 94,
-              name: 'Cakes & pastries',
-              popular: false,
-              category: {
-                id: 15,
-                name: 'Food waste',
+              {
+                id: 7,
+                name: 'Toilet roll tubes',
                 popular: false,
+                category: {
+                  id: 1,
+                  name: 'Cardboard',
+                  popular: false,
+                },
               },
-            },
-            {
-              id: 95,
-              name: 'Dairy products - eggs, cheese & milk',
-              popular: false,
-              category: {
-                id: 15,
-                name: 'Food waste',
+            ],
+          },
+          {
+            name: 'Box',
+            displayName: 'Box (35 to 60L)',
+            bodyColour: '#2d9cdb',
+            lidColour: null,
+            notes: [],
+            materials: [
+              {
+                id: 20,
+                name: 'Glass bottles and jars',
+                popular: true,
+                category: {
+                  id: 4,
+                  name: 'Glass',
+                  popular: false,
+                },
+              },
+            ],
+          },
+        ],
+        notes: null,
+      },
+      {
+        name: 'Subscription garden scheme - open to all',
+        type: 'Garden',
+        containers: [
+          {
+            name: 'Wheeled Bin',
+            displayName: 'Wheeled Bin (120L)',
+            bodyColour: '#3cb848',
+            lidColour: '#3cb848',
+            notes: ['Subscription costs £55 from April 2023'],
+            materials: [
+              {
+                id: 86,
+                name: 'Flowers',
                 popular: false,
+                category: {
+                  id: 14,
+                  name: 'Garden waste',
+                  popular: false,
+                },
               },
-            },
-            {
-              id: 96,
-              name: 'Raw & cooked meat including bones',
-              popular: false,
-              category: {
-                id: 15,
-                name: 'Food waste',
+              {
+                id: 87,
+                name: 'Grass cuttings',
                 popular: false,
+                category: {
+                  id: 14,
+                  name: 'Garden waste',
+                  popular: false,
+                },
               },
-            },
-            {
-              id: 97,
-              name: 'Raw & cooked fish including bones',
-              popular: false,
-              category: {
-                id: 15,
-                name: 'Food waste',
+              {
+                id: 88,
+                name: 'Leaves',
                 popular: false,
+                category: {
+                  id: 14,
+                  name: 'Garden waste',
+                  popular: false,
+                },
               },
-            },
-            {
-              id: 98,
-              name: 'Raw & cooked vegetables including peelings',
-              popular: false,
-              category: {
-                id: 15,
-                name: 'Food waste',
+              {
+                id: 89,
+                name: 'Plants',
                 popular: false,
+                category: {
+                  id: 14,
+                  name: 'Garden waste',
+                  popular: false,
+                },
               },
-            },
-            {
-              id: 99,
-              name: 'Rice',
-              popular: false,
-              category: {
-                id: 15,
-                name: 'Food waste',
+              {
+                id: 90,
+                name: 'Prunings & twigs',
                 popular: false,
+                category: {
+                  id: 14,
+                  name: 'Garden waste',
+                  popular: false,
+                },
               },
-            },
-            {
-              id: 100,
-              name: 'Pasta',
-              popular: false,
-              category: {
-                id: 15,
-                name: 'Food waste',
+              {
+                id: 91,
+                name: 'Weeds',
                 popular: false,
+                category: {
+                  id: 14,
+                  name: 'Garden waste',
+                  popular: false,
+                },
               },
-            },
-            {
-              id: 101,
-              name: 'Beans & pulses',
-              popular: false,
-              category: {
-                id: 15,
-                name: 'Food waste',
+              {
+                id: 92,
+                name: 'Christmas trees',
                 popular: false,
+                category: {
+                  id: 14,
+                  name: 'Garden waste',
+                  popular: false,
+                },
               },
-            },
-            {
-              id: 102,
-              name: 'Uneaten food & plate scrapings',
-              popular: false,
-              category: {
-                id: 15,
-                name: 'Food waste',
+            ],
+            cost: 55,
+          },
+        ],
+        notes:
+          'Fortnightly Collections through out the year. Collections suspended Christmas week and New Years week.',
+      },
+      {
+        name: 'All properties',
+        type: 'Residual',
+        containers: [
+          {
+            name: 'Wheeled Bin',
+            displayName: 'Wheeled Bin (240L)',
+            bodyColour: '#4f4f4f',
+            lidColour: '#4f4f4f',
+            notes: [],
+          },
+          {
+            name: 'Non-Reusable Sack',
+            displayName: 'Non-Reusable Sack',
+            bodyColour: '#4f4f4f',
+            lidColour: '#4f4f4f',
+            notes: [],
+          },
+          {
+            name: 'Communal Wheeled Bin',
+            displayName: 'Communal Wheeled Bin (181 to 240L)',
+            bodyColour: '#4f4f4f',
+            lidColour: null,
+            notes: [],
+          },
+        ],
+        notes: '870 are on 140 litre wheeled bins',
+      },
+    ],
+    'Kerbside properties': [
+      {
+        name: 'All kerbside properties',
+        type: 'Food',
+        containers: [
+          {
+            name: 'Kerbside Caddy',
+            displayName: 'Kerbside Caddy (23L)',
+            bodyColour: '#3cb848',
+            lidColour: null,
+            notes: [
+              'Any bag accepted, bread bags, carrier bags, black bags, cereal bags.',
+            ],
+            materials: [
+              {
+                id: 93,
+                name: 'Bread',
                 popular: false,
+                category: {
+                  id: 15,
+                  name: 'Food waste',
+                  popular: false,
+                },
               },
-            },
-            {
-              id: 103,
-              name: 'Tea leaves, tea bags & coffee grinds',
-              popular: false,
-              category: {
-                id: 15,
-                name: 'Food waste',
+              {
+                id: 94,
+                name: 'Cakes & pastries',
                 popular: false,
+                category: {
+                  id: 15,
+                  name: 'Food waste',
+                  popular: false,
+                },
               },
-            },
-            {
-              id: 104,
-              name: 'Uneaten food (remove packaging)',
-              popular: false,
-              category: {
-                id: 15,
-                name: 'Food waste',
+              {
+                id: 95,
+                name: 'Dairy products - eggs, cheese & milk',
                 popular: false,
+                category: {
+                  id: 15,
+                  name: 'Food waste',
+                  popular: false,
+                },
               },
-            },
-          ],
-          interiorColour: '#219653',
-        },
-        {
-          name: 'Kitchen Caddy',
-          displayName: 'Kitchen Caddy (7L)',
-          bodyColour: '#3cb848',
-          lidColour: '#3cb848',
-          notes:
-            'Any bag accepted, bread bags, carrier bags, black bags, cereal bags.',
-          materials: [
-            {
-              id: 93,
-              name: 'Bread',
-              popular: false,
-              category: {
-                id: 15,
-                name: 'Food waste',
+              {
+                id: 96,
+                name: 'Raw & cooked meat including bones',
                 popular: false,
+                category: {
+                  id: 15,
+                  name: 'Food waste',
+                  popular: false,
+                },
               },
-            },
-            {
-              id: 94,
-              name: 'Cakes & pastries',
-              popular: false,
-              category: {
-                id: 15,
-                name: 'Food waste',
+              {
+                id: 97,
+                name: 'Raw & cooked fish including bones',
                 popular: false,
+                category: {
+                  id: 15,
+                  name: 'Food waste',
+                  popular: false,
+                },
               },
-            },
-            {
-              id: 95,
-              name: 'Dairy products - eggs, cheese & milk',
-              popular: false,
-              category: {
-                id: 15,
-                name: 'Food waste',
+              {
+                id: 98,
+                name: 'Raw & cooked vegetables including peelings',
                 popular: false,
+                category: {
+                  id: 15,
+                  name: 'Food waste',
+                  popular: false,
+                },
               },
-            },
-            {
-              id: 96,
-              name: 'Raw & cooked meat including bones',
-              popular: false,
-              category: {
-                id: 15,
-                name: 'Food waste',
+              {
+                id: 99,
+                name: 'Rice',
                 popular: false,
+                category: {
+                  id: 15,
+                  name: 'Food waste',
+                  popular: false,
+                },
               },
-            },
-            {
-              id: 97,
-              name: 'Raw & cooked fish including bones',
-              popular: false,
-              category: {
-                id: 15,
-                name: 'Food waste',
+              {
+                id: 100,
+                name: 'Pasta',
                 popular: false,
+                category: {
+                  id: 15,
+                  name: 'Food waste',
+                  popular: false,
+                },
               },
-            },
-            {
-              id: 98,
-              name: 'Raw & cooked vegetables including peelings',
-              popular: false,
-              category: {
-                id: 15,
-                name: 'Food waste',
+              {
+                id: 101,
+                name: 'Beans & pulses',
                 popular: false,
+                category: {
+                  id: 15,
+                  name: 'Food waste',
+                  popular: false,
+                },
               },
-            },
-            {
-              id: 99,
-              name: 'Rice',
-              popular: false,
-              category: {
-                id: 15,
-                name: 'Food waste',
+              {
+                id: 102,
+                name: 'Uneaten food & plate scrapings',
                 popular: false,
+                category: {
+                  id: 15,
+                  name: 'Food waste',
+                  popular: false,
+                },
               },
-            },
-            {
-              id: 100,
-              name: 'Pasta',
-              popular: false,
-              category: {
-                id: 15,
-                name: 'Food waste',
+              {
+                id: 103,
+                name: 'Tea leaves, tea bags & coffee grinds',
                 popular: false,
+                category: {
+                  id: 15,
+                  name: 'Food waste',
+                  popular: false,
+                },
               },
-            },
-            {
-              id: 101,
-              name: 'Beans & pulses',
-              popular: false,
-              category: {
-                id: 15,
-                name: 'Food waste',
+              {
+                id: 104,
+                name: 'Uneaten food (remove packaging)',
                 popular: false,
+                category: {
+                  id: 15,
+                  name: 'Food waste',
+                  popular: false,
+                },
               },
-            },
-            {
-              id: 102,
-              name: 'Uneaten food & plate scrapings',
-              popular: false,
-              category: {
-                id: 15,
-                name: 'Food waste',
+            ],
+            interiorColour: '#219653',
+          },
+          {
+            name: 'Kitchen Caddy',
+            displayName: 'Kitchen Caddy (7L)',
+            bodyColour: '#3cb848',
+            lidColour: '#3cb848',
+            notes: [
+              'Any bag accepted, bread bags, carrier bags, black bags, cereal bags.',
+            ],
+            materials: [
+              {
+                id: 93,
+                name: 'Bread',
                 popular: false,
+                category: {
+                  id: 15,
+                  name: 'Food waste',
+                  popular: false,
+                },
               },
-            },
-            {
-              id: 103,
-              name: 'Tea leaves, tea bags & coffee grinds',
-              popular: false,
-              category: {
-                id: 15,
-                name: 'Food waste',
+              {
+                id: 94,
+                name: 'Cakes & pastries',
                 popular: false,
+                category: {
+                  id: 15,
+                  name: 'Food waste',
+                  popular: false,
+                },
               },
-            },
-            {
-              id: 104,
-              name: 'Uneaten food (remove packaging)',
-              popular: false,
-              category: {
-                id: 15,
-                name: 'Food waste',
+              {
+                id: 95,
+                name: 'Dairy products - eggs, cheese & milk',
                 popular: false,
+                category: {
+                  id: 15,
+                  name: 'Food waste',
+                  popular: false,
+                },
               },
-            },
-          ],
-          interiorColour: '#219653',
-        },
-      ],
-    },
-    {
-      name: 'Subscription garden scheme - open to all',
-      containers: [
-        {
-          name: 'Wheeled Bin',
-          displayName: 'Wheeled Bin (120L)',
-          bodyColour: '#3cb848',
-          lidColour: '#3cb848',
-          notes: 'Subscription costs \u00a355 from April 2023',
-          materials: [
-            {
-              id: 86,
-              name: 'Flowers',
-              popular: false,
-              category: {
+              {
+                id: 96,
+                name: 'Raw & cooked meat including bones',
+                popular: false,
+                category: {
+                  id: 15,
+                  name: 'Food waste',
+                  popular: false,
+                },
+              },
+              {
+                id: 97,
+                name: 'Raw & cooked fish including bones',
+                popular: false,
+                category: {
+                  id: 15,
+                  name: 'Food waste',
+                  popular: false,
+                },
+              },
+              {
+                id: 98,
+                name: 'Raw & cooked vegetables including peelings',
+                popular: false,
+                category: {
+                  id: 15,
+                  name: 'Food waste',
+                  popular: false,
+                },
+              },
+              {
+                id: 99,
+                name: 'Rice',
+                popular: false,
+                category: {
+                  id: 15,
+                  name: 'Food waste',
+                  popular: false,
+                },
+              },
+              {
+                id: 100,
+                name: 'Pasta',
+                popular: false,
+                category: {
+                  id: 15,
+                  name: 'Food waste',
+                  popular: false,
+                },
+              },
+              {
+                id: 101,
+                name: 'Beans & pulses',
+                popular: false,
+                category: {
+                  id: 15,
+                  name: 'Food waste',
+                  popular: false,
+                },
+              },
+              {
+                id: 102,
+                name: 'Uneaten food & plate scrapings',
+                popular: false,
+                category: {
+                  id: 15,
+                  name: 'Food waste',
+                  popular: false,
+                },
+              },
+              {
+                id: 103,
+                name: 'Tea leaves, tea bags & coffee grinds',
+                popular: false,
+                category: {
+                  id: 15,
+                  name: 'Food waste',
+                  popular: false,
+                },
+              },
+              {
+                id: 104,
+                name: 'Uneaten food (remove packaging)',
+                popular: false,
+                category: {
+                  id: 15,
+                  name: 'Food waste',
+                  popular: false,
+                },
+              },
+            ],
+            interiorColour: '#219653',
+          },
+        ],
+        notes: null,
+      },
+      {
+        name: 'All properties',
+        type: 'Dry',
+        containers: [
+          {
+            name: 'Reusable Sack',
+            displayName: 'Reusable Sack',
+            bodyColour: '#3cb848',
+            lidColour: null,
+            notes: [],
+            materials: [
+              {
+                id: 10,
+                name: 'Junk mail',
+                popular: false,
+                category: {
+                  id: 2,
+                  name: 'Paper',
+                  popular: false,
+                },
+              },
+              {
+                id: 11,
+                name: 'Magazines',
+                popular: false,
+                category: {
+                  id: 2,
+                  name: 'Paper',
+                  popular: false,
+                },
+              },
+              {
+                id: 12,
+                name: 'Newspapers',
+                popular: false,
+                category: {
+                  id: 2,
+                  name: 'Paper',
+                  popular: false,
+                },
+              },
+              {
+                id: 13,
+                name: 'Shredded paper',
+                popular: false,
+                category: {
+                  id: 2,
+                  name: 'Paper',
+                  popular: false,
+                },
+              },
+              {
                 id: 14,
-                name: 'Garden waste',
+                name: 'Telephone directories',
                 popular: false,
+                category: {
+                  id: 2,
+                  name: 'Paper',
+                  popular: false,
+                },
               },
-            },
-            {
-              id: 87,
-              name: 'Grass cuttings',
-              popular: false,
-              category: {
-                id: 14,
-                name: 'Garden waste',
+              {
+                id: 15,
+                name: 'Window envelopes',
                 popular: false,
+                category: {
+                  id: 2,
+                  name: 'Paper',
+                  popular: false,
+                },
               },
-            },
-            {
-              id: 88,
-              name: 'Leaves',
-              popular: false,
-              category: {
-                id: 14,
-                name: 'Garden waste',
+              {
+                id: 52,
+                name: 'Clothing',
+                popular: true,
+                category: {
+                  id: 9,
+                  name: 'Textiles',
+                  popular: false,
+                },
+              },
+              {
+                id: 54,
+                name: 'Shoes & bags',
                 popular: false,
+                category: {
+                  id: 9,
+                  name: 'Textiles',
+                  popular: false,
+                },
               },
-            },
-            {
-              id: 89,
-              name: 'Plants',
-              popular: false,
-              category: {
-                id: 14,
-                name: 'Garden waste',
+            ],
+          },
+          {
+            name: 'Box',
+            displayName: 'Box (35 to 60L)',
+            bodyColour: '#4f4f4f',
+            lidColour: '#4f4f4f',
+            notes: ['containers can be black or green.'],
+            materials: [
+              {
+                id: 18,
+                name: 'Aluminium foil',
                 popular: false,
+                category: {
+                  id: 3,
+                  name: 'Foil',
+                  popular: false,
+                },
               },
-            },
-            {
-              id: 90,
-              name: 'Prunings & twigs',
-              popular: false,
-              category: {
-                id: 14,
-                name: 'Garden waste',
+              {
+                id: 19,
+                name: 'Foil trays',
                 popular: false,
+                category: {
+                  id: 3,
+                  name: 'Foil',
+                  popular: false,
+                },
               },
-            },
-            {
-              id: 91,
-              name: 'Weeds',
-              popular: false,
-              category: {
-                id: 14,
-                name: 'Garden waste',
+              {
+                id: 23,
+                name: 'Aerosols',
                 popular: false,
+                category: {
+                  id: 5,
+                  name: 'Metal',
+                  popular: false,
+                },
               },
-            },
-            {
-              id: 92,
-              name: 'Christmas trees',
-              popular: false,
-              category: {
-                id: 14,
-                name: 'Garden waste',
+              {
+                id: 24,
+                name: 'Drinks cans',
                 popular: false,
+                category: {
+                  id: 5,
+                  name: 'Metal',
+                  popular: false,
+                },
               },
-            },
-          ],
-          cost: 55,
-        },
-      ],
-    },
-  ],
-  residualStreams: [
-    {
-      name: 'All properties',
-      containers: [
-        {
-          name: 'Wheeled Bin',
-          displayName: 'Wheeled Bin (240L)',
-          bodyColour: '#4f4f4f',
-          lidColour: '#4f4f4f',
-          notes: null,
-        },
-        {
-          name: 'Non-Reusable Sack',
-          displayName: 'Non-Reusable Sack',
-          bodyColour: '#4f4f4f',
-          lidColour: '#4f4f4f',
-          notes: null,
-        },
-        {
-          name: 'Communal Wheeled Bin',
-          displayName: 'Communal Wheeled Bin (181 to 240L)',
-          bodyColour: '#4f4f4f',
-          lidColour: null,
-          notes: null,
-        },
-      ],
-    },
-  ],
+              {
+                id: 25,
+                name: 'Food tins',
+                popular: false,
+                category: {
+                  id: 5,
+                  name: 'Metal',
+                  popular: false,
+                },
+              },
+              {
+                id: 26,
+                name: 'Metal lids from glass jars',
+                popular: false,
+                category: {
+                  id: 5,
+                  name: 'Metal',
+                  popular: false,
+                },
+              },
+              {
+                id: 42,
+                name: 'Household cleaner & detergent bottles',
+                popular: false,
+                category: {
+                  id: 7,
+                  name: 'Plastic bottles',
+                  popular: false,
+                },
+              },
+              {
+                id: 43,
+                name: 'Plastic milk bottles',
+                popular: false,
+                category: {
+                  id: 7,
+                  name: 'Plastic bottles',
+                  popular: false,
+                },
+              },
+              {
+                id: 44,
+                name: 'Plastic drinks bottles',
+                popular: false,
+                category: {
+                  id: 7,
+                  name: 'Plastic bottles',
+                  popular: false,
+                },
+              },
+              {
+                id: 45,
+                name: 'Toiletries & shampoo bottles',
+                popular: false,
+                category: {
+                  id: 7,
+                  name: 'Plastic bottles',
+                  popular: false,
+                },
+              },
+              {
+                id: 47,
+                name: 'Food pots & tubs',
+                popular: false,
+                category: {
+                  id: 8,
+                  name: 'Plastic packaging',
+                  popular: false,
+                },
+              },
+              {
+                id: 48,
+                name: 'Margarine tubs',
+                popular: false,
+                category: {
+                  id: 8,
+                  name: 'Plastic packaging',
+                  popular: false,
+                },
+              },
+              {
+                id: 50,
+                name: 'Plastic trays',
+                popular: false,
+                category: {
+                  id: 8,
+                  name: 'Plastic packaging',
+                  popular: false,
+                },
+              },
+              {
+                id: 51,
+                name: 'Yoghurt pots',
+                popular: false,
+                category: {
+                  id: 8,
+                  name: 'Plastic packaging',
+                  popular: false,
+                },
+              },
+              {
+                id: 58,
+                name: 'Laptops',
+                popular: false,
+                category: {
+                  id: 10,
+                  name: 'Electricals',
+                  popular: false,
+                },
+              },
+              {
+                id: 59,
+                name: 'Computers',
+                popular: false,
+                category: {
+                  id: 10,
+                  name: 'Electricals',
+                  popular: false,
+                },
+              },
+              {
+                id: 60,
+                name: 'TVs',
+                popular: false,
+                category: {
+                  id: 10,
+                  name: 'Electricals',
+                  popular: false,
+                },
+              },
+              {
+                id: 61,
+                name: 'DVD/CD players',
+                popular: false,
+                category: {
+                  id: 10,
+                  name: 'Electricals',
+                  popular: false,
+                },
+              },
+              {
+                id: 62,
+                name: 'Hi-fi',
+                popular: false,
+                category: {
+                  id: 10,
+                  name: 'Electricals',
+                  popular: false,
+                },
+              },
+              {
+                id: 63,
+                name: 'Telephones/fax',
+                popular: false,
+                category: {
+                  id: 10,
+                  name: 'Electricals',
+                  popular: false,
+                },
+              },
+              {
+                id: 64,
+                name: 'Mobile phones',
+                popular: true,
+                category: {
+                  id: 10,
+                  name: 'Electricals',
+                  popular: false,
+                },
+              },
+              {
+                id: 65,
+                name: 'Cameras',
+                popular: false,
+                category: {
+                  id: 10,
+                  name: 'Electricals',
+                  popular: false,
+                },
+              },
+              {
+                id: 67,
+                name: 'Hairdryers & electric toothbrushes',
+                popular: false,
+                category: {
+                  id: 10,
+                  name: 'Electricals',
+                  popular: false,
+                },
+              },
+              {
+                id: 69,
+                name: 'Electronic toys & games',
+                popular: false,
+                category: {
+                  id: 10,
+                  name: 'Electricals',
+                  popular: false,
+                },
+              },
+              {
+                id: 70,
+                name: 'Energy-saving light bulbs',
+                popular: false,
+                category: {
+                  id: 10,
+                  name: 'Electricals',
+                  popular: false,
+                },
+              },
+              {
+                id: 71,
+                name: 'Microwave',
+                popular: false,
+                category: {
+                  id: 10,
+                  name: 'Electricals',
+                  popular: false,
+                },
+              },
+              {
+                id: 72,
+                name: 'Table lamps',
+                popular: false,
+                category: {
+                  id: 10,
+                  name: 'Electricals',
+                  popular: false,
+                },
+              },
+              {
+                id: 106,
+                name: 'Set top boxes',
+                popular: false,
+                category: {
+                  id: 10,
+                  name: 'Electricals',
+                  popular: false,
+                },
+              },
+              {
+                id: 107,
+                name: 'Routers',
+                popular: false,
+                category: {
+                  id: 10,
+                  name: 'Electricals',
+                  popular: false,
+                },
+              },
+            ],
+          },
+          {
+            name: 'Reusable Sack',
+            displayName: 'Reusable Sack',
+            bodyColour: '#ad7849',
+            lidColour: null,
+            notes: [],
+            materials: [
+              {
+                id: 1,
+                name: 'Cardboard egg boxes',
+                popular: false,
+                category: {
+                  id: 1,
+                  name: 'Cardboard',
+                  popular: false,
+                },
+              },
+              {
+                id: 2,
+                name: 'Cardboard fruit and veg punnets',
+                popular: false,
+                category: {
+                  id: 1,
+                  name: 'Cardboard',
+                  popular: false,
+                },
+              },
+              {
+                id: 3,
+                name: 'Cardboard sleeves',
+                popular: false,
+                category: {
+                  id: 1,
+                  name: 'Cardboard',
+                  popular: false,
+                },
+              },
+              {
+                id: 4,
+                name: 'Cereal boxes',
+                popular: false,
+                category: {
+                  id: 1,
+                  name: 'Cardboard',
+                  popular: false,
+                },
+              },
+              {
+                id: 5,
+                name: 'Corrugated cardboard',
+                popular: false,
+                category: {
+                  id: 1,
+                  name: 'Cardboard',
+                  popular: false,
+                },
+              },
+              {
+                id: 7,
+                name: 'Toilet roll tubes',
+                popular: false,
+                category: {
+                  id: 1,
+                  name: 'Cardboard',
+                  popular: false,
+                },
+              },
+            ],
+          },
+          {
+            name: 'Box',
+            displayName: 'Box (35 to 60L)',
+            bodyColour: '#2d9cdb',
+            lidColour: null,
+            notes: [],
+            materials: [
+              {
+                id: 20,
+                name: 'Glass bottles and jars',
+                popular: true,
+                category: {
+                  id: 4,
+                  name: 'Glass',
+                  popular: false,
+                },
+              },
+            ],
+          },
+        ],
+        notes: null,
+      },
+      {
+        name: 'Subscription garden scheme - open to all',
+        type: 'Garden',
+        containers: [
+          {
+            name: 'Wheeled Bin',
+            displayName: 'Wheeled Bin (120L)',
+            bodyColour: '#3cb848',
+            lidColour: '#3cb848',
+            notes: ['Subscription costs £55 from April 2023'],
+            materials: [
+              {
+                id: 86,
+                name: 'Flowers',
+                popular: false,
+                category: {
+                  id: 14,
+                  name: 'Garden waste',
+                  popular: false,
+                },
+              },
+              {
+                id: 87,
+                name: 'Grass cuttings',
+                popular: false,
+                category: {
+                  id: 14,
+                  name: 'Garden waste',
+                  popular: false,
+                },
+              },
+              {
+                id: 88,
+                name: 'Leaves',
+                popular: false,
+                category: {
+                  id: 14,
+                  name: 'Garden waste',
+                  popular: false,
+                },
+              },
+              {
+                id: 89,
+                name: 'Plants',
+                popular: false,
+                category: {
+                  id: 14,
+                  name: 'Garden waste',
+                  popular: false,
+                },
+              },
+              {
+                id: 90,
+                name: 'Prunings & twigs',
+                popular: false,
+                category: {
+                  id: 14,
+                  name: 'Garden waste',
+                  popular: false,
+                },
+              },
+              {
+                id: 91,
+                name: 'Weeds',
+                popular: false,
+                category: {
+                  id: 14,
+                  name: 'Garden waste',
+                  popular: false,
+                },
+              },
+              {
+                id: 92,
+                name: 'Christmas trees',
+                popular: false,
+                category: {
+                  id: 14,
+                  name: 'Garden waste',
+                  popular: false,
+                },
+              },
+            ],
+            cost: 55,
+          },
+        ],
+        notes:
+          'Fortnightly Collections through out the year. Collections suspended Christmas week and New Years week.',
+      },
+      {
+        name: 'All properties',
+        type: 'Residual',
+        containers: [
+          {
+            name: 'Wheeled Bin',
+            displayName: 'Wheeled Bin (240L)',
+            bodyColour: '#4f4f4f',
+            lidColour: '#4f4f4f',
+            notes: [],
+          },
+          {
+            name: 'Non-Reusable Sack',
+            displayName: 'Non-Reusable Sack',
+            bodyColour: '#4f4f4f',
+            lidColour: '#4f4f4f',
+            notes: [],
+          },
+          {
+            name: 'Communal Wheeled Bin',
+            displayName: 'Communal Wheeled Bin (181 to 240L)',
+            bodyColour: '#4f4f4f',
+            lidColour: null,
+            notes: [],
+          },
+        ],
+        notes: '870 are on 140 litre wheeled bins',
+      },
+    ],
+  },
 };

--- a/tests/mocks/localAuthority.ts
+++ b/tests/mocks/localAuthority.ts
@@ -3,7 +3,7 @@ import { LocalAuthority } from '@/types/locatorApi';
 
 export const LOCAL_AUTHORITY_ENDPOINT = `${config.locatorApiPath}local-authority/**`;
 
-export const localAuthority: LocalAuthority = {
+export const LocalAuthorityResponse: LocalAuthority = {
   id: 321,
   name: 'North Devon District Council',
   lastUpdate: '2024-02-07T15:47:56.064Z',

--- a/tests/unit/getPropertiesByMaterial.test.ts
+++ b/tests/unit/getPropertiesByMaterial.test.ts
@@ -1,0 +1,50 @@
+import { expect, test } from 'vitest';
+
+import getPropertiesByMaterial from '@/lib/getPropertiesByMaterial';
+import { LocalAuthority, PROPERTY_TYPE } from '@/types/locatorApi';
+
+test('Returns properties that accept the given material', () => {
+  const properties = {
+    [PROPERTY_TYPE.ALL]: [
+      {
+        name: 'Communal collections',
+        containers: [
+          {
+            name: 'Container 1',
+            materials: [{ id: 1 }, { id: 2 }],
+          },
+          {
+            name: 'Container 2',
+            materials: [{ id: 1 }, { id: 2 }],
+          },
+          {
+            name: 'Container 3',
+            materials: [{ id: 5 }, { id: 2 }],
+          },
+        ],
+      },
+      {
+        name: 'Non-city centre households',
+        containers: [
+          {
+            materials: [{ id: 3 }, { id: 4 }],
+          },
+        ],
+      },
+    ],
+    [PROPERTY_TYPE.KERBSIDE]: [
+      {
+        name: 'Non-city centre households',
+        containers: [
+          {
+            materials: [{ id: 3 }, { id: 4 }],
+          },
+        ],
+      },
+    ],
+  } as LocalAuthority['properties'];
+
+  expect(getPropertiesByMaterial(1, properties)).toEqual({
+    [PROPERTY_TYPE.ALL]: properties[PROPERTY_TYPE.ALL],
+  });
+});

--- a/tests/unit/getPropertyDisplayName.test.ts
+++ b/tests/unit/getPropertyDisplayName.test.ts
@@ -36,8 +36,32 @@ test('Returns the first scheme name if there is no dry scheme', () => {
         type: 'Food',
       },
       {
-        name: drySchemeName,
+        name: 'Another scheme',
         type: 'Garden',
+      },
+      {
+        name: 'Communal collections',
+        type: 'Food',
+      },
+    ],
+  } as LocalAuthority['properties'];
+
+  expect(getPropertyDisplayName(properties[PROPERTY_TYPE.ALL])).toEqual(
+    firstSchemeName,
+  );
+});
+
+test('Returns the first scheme name if the dry scheme is named all properties', () => {
+  const firstSchemeName = 'Non-city centre households';
+  const properties = {
+    [PROPERTY_TYPE.ALL]: [
+      {
+        name: firstSchemeName,
+        type: 'Food',
+      },
+      {
+        name: PROPERTY_TYPE.ALL,
+        type: 'Dry',
       },
       {
         name: 'Communal collections',

--- a/tests/unit/getPropertyDisplayName.test.ts
+++ b/tests/unit/getPropertyDisplayName.test.ts
@@ -1,0 +1,52 @@
+import { expect, test } from 'vitest';
+
+import getPropertyDisplayName from '@/lib/getPropertyDisplayName';
+import { LocalAuthority, PROPERTY_TYPE } from '@/types/locatorApi';
+
+test('Returns the first dry scheme name if there is one', () => {
+  const drySchemeName = 'This one';
+  const properties = {
+    [PROPERTY_TYPE.ALL]: [
+      {
+        name: 'Non-city centre households',
+        type: 'Food',
+      },
+      {
+        name: drySchemeName,
+        type: 'Dry',
+      },
+      {
+        name: 'Communal collections',
+        type: 'Dry',
+      },
+    ],
+  } as LocalAuthority['properties'];
+
+  expect(getPropertyDisplayName(properties[PROPERTY_TYPE.ALL])).toEqual(
+    drySchemeName,
+  );
+});
+
+test('Returns the first scheme name if there is no dry scheme', () => {
+  const firstSchemeName = 'Non-city centre households';
+  const properties = {
+    [PROPERTY_TYPE.ALL]: [
+      {
+        name: firstSchemeName,
+        type: 'Food',
+      },
+      {
+        name: drySchemeName,
+        type: 'Garden',
+      },
+      {
+        name: 'Communal collections',
+        type: 'Food',
+      },
+    ],
+  } as LocalAuthority['properties'];
+
+  expect(getPropertyDisplayName(properties[PROPERTY_TYPE.ALL])).toEqual(
+    firstSchemeName,
+  );
+});


### PR DESCRIPTION
Adds support for the new Local Authority API response to allow schemes to be split up by property type.

**Sonarcloud warnings**

- Its main issue is duplication, but all the duplication comes from tests and mock data
- It's complaining that summary isn't a native interactive element so needs keyboard handlers but it is an interactive element with a role of button and the keyboard listeners are already bound