### PR TITLE
Fix package version header

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,8 @@
 name: Deploy to Pages
 on:
   push:
-    branches: ["main"]
+    branches:
+      - main
   workflow_dispatch:
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,9 @@ jobs:
         with:
           node-version-file: .nvmrc
           cache: npm
+      - name: Get package version
+        id: package-version
+        uses: martinbeentjes/npm-get-version-action@v1.3.1
       - name: Install dependencies
         run: npm ci
       - name: Build
@@ -41,6 +44,7 @@ jobs:
           VITE_HERE_MAPS_PLACES_KEY: ${{ vars.VITE_HERE_MAPS_PLACES_KEY }}
           VITE_RECYCLING_LOCATOR_API: https://rl-v2.wrap.etch.tech/widget/
           VITE_PUBLIC_PATH: https://unpkg.com/@etchteam/recycling-locator/dist/
+          VITE_PACKAGE_VERSION: ${{ steps.package-version.outputs.current-version}}
       - name: Publish
         run: npm run release
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
           VITE_SENTRY_DSN: 'https://423f7067367670f8a6b166e99b61726d@o1156292.ingest.us.sentry.io/4506864957194240'
           VITE_HERE_MAPS_PLACES_KEY: ${{ vars.VITE_HERE_MAPS_PLACES_KEY }}
           VITE_RECYCLING_LOCATOR_API: https://rl-v2.wrap.etch.tech/widget/
-          VITE_PUBLIC_PATH: https://unpkg.com/@etchteam/recycling-locator/dist/
+          VITE_PUBLIC_PATH: https://cdn.jsdelivr.net/npm/@etchteam/recycling-locator@${{ steps.package-version.outputs.current-version}}/dist/
           VITE_PACKAGE_VERSION: ${{ steps.package-version.outputs.current-version}}
       - name: Publish
         run: npm run release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
           VITE_SENTRY_DSN: 'https://423f7067367670f8a6b166e99b61726d@o1156292.ingest.us.sentry.io/4506864957194240'
           VITE_HERE_MAPS_PLACES_KEY: ${{ vars.VITE_HERE_MAPS_PLACES_KEY }}
           VITE_RECYCLING_LOCATOR_API: https://rl-v2.wrap.etch.tech/widget/
-          VITE_PUBLIC_PATH: https://cdn.jsdelivr.net/npm/@etchteam/recycling-locator@${{ steps.package-version.outputs.current-version}}/dist/
+          VITE_PUBLIC_PATH: https://cdn.jsdelivr.net/npm/@etchteam/recycling-locator/dist/
           VITE_PACKAGE_VERSION: ${{ steps.package-version.outputs.current-version}}
       - name: Publish
         run: npm run release

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,7 +6,7 @@ const hostname =
   typeof window !== 'undefined' ? window?.location?.hostname : 'localhost'; // Can be undefined in tests
 
 const config = {
-  packageVersion: import.meta.env.VITE_PACKAGE_VERSION ?? 0,
+  packageVersion: import.meta.env.VITE_PACKAGE_VERSION ?? '1.0.0',
   publicPath: PUBLIC_PATH,
   imagePath: `${PUBLIC_PATH}images/`,
   mapsPlacesKey: import.meta.env.VITE_HERE_MAPS_PLACES_KEY,


### PR DESCRIPTION
Fix the package version header sent to the API coming through as 0.

This will actually send the previous package version, because semantic release won't have run yet, but it's close enough.