### PR TITLE
Add non-index entrypoints to demo

### DIFF
--- a/demo/vite.config.js
+++ b/demo/vite.config.js
@@ -1,3 +1,5 @@
+import { resolve } from 'node:path';
+
 import { defineConfig, loadEnv } from 'vite';
 
 export default defineConfig(({ mode }) => {
@@ -8,6 +10,15 @@ export default defineConfig(({ mode }) => {
       'process.env': env,
     },
     base: '/recycling-locator',
+    build: {
+      rollupOptions: {
+        input: {
+          index: resolve(__dirname, 'index.html'),
+          welsh: resolve(__dirname, 'welsh.html'),
+          branded: resolve(__dirname, 'branded.html'),
+        },
+      },
+    },
   };
 
   return config;


### PR DESCRIPTION
At the moment the sub-routes at https://etchteam.github.io/recycling-locator/ aren't working.

This fixes the issue using the approach outlined in the Vite docs https://vitejs.dev/guide/build#multi-page-app