### PR TITLE
NPM install demo deps

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Install demo dependencies
-        run: npm ci
+        run: npm install
         working-directory: demo
       - name: Build
         run: npm run build


### PR DESCRIPTION
`npm ci` is locking the locator version to what's in the package-lock, needs to update on each release.