### PR TITLE
Fix marker env key name

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Build
         run: npm run build
         env:
-          MARKER_KEY: 65ef397bdb8bc8524e2e763b
+          VITE_MARKER_KEY: 65ef397bdb8bc8524e2e763b
         working-directory: demo
       - name: Setup Pages
         uses: actions/configure-pages@v4


### PR DESCRIPTION
Marker stopped showing up on the demo site, I think it's because this env is named wrong, public envs in vite need to be prefixed vite_ as a safety measure.