### PR TITLE
Disable animations whilst in test mode

### DIFF
--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -16,6 +16,10 @@ article {
 }
 
 .recycling-locator-test-mode {
+  /* Stop animations */
+  --diamond-transition-duration-boing: 0s;
+  --diamond-transition-duration: 0s;
+  --diamond-transition-enter-duration: 0s;
   /* Height restriction is removed for snapshots */
   height: auto;
 }

--- a/tests/end-to-end/home.test.ts
+++ b/tests/end-to-end/home.test.ts
@@ -173,7 +173,6 @@ describeEndToEndTest('Home recycling', () => {
     await expect(positiveSearchText).not.toBeVisible();
     await input.fill('Plastic drinks bottles');
     await input.press('Enter');
-    await page.waitForTimeout(500); // diamond enter transition duration
     await expect(negativeSearchText).not.toBeVisible();
     await expect(positiveSearchText).toBeVisible();
     await snapshot(page, 'Home recycling collection details');

--- a/tests/end-to-end/material.test.ts
+++ b/tests/end-to-end/material.test.ts
@@ -43,7 +43,6 @@ describeEndToEndTest('Material page', () => {
     await expect(recyclableText).toBeVisible();
     await expect(homeText).toBeVisible();
     await expect(locationsText).toBeVisible();
-    await page.waitForTimeout(500);
     await snapshot(page, 'Material result single');
   });
 
@@ -114,7 +113,6 @@ describeEndToEndTest('Material page', () => {
     await expect(somePropertiesText).toBeVisible();
     await expect(schemeOneText).toBeVisible();
     await expect(locationsText).toBeVisible();
-    await page.waitForTimeout(500);
     await snapshot(page, 'Material result multiple');
   });
 
@@ -247,7 +245,6 @@ describeEndToEndTest('Material page', () => {
     await expect(recyclableText).toBeVisible();
     await expect(homeText).toBeVisible();
     await expect(locationsText).toBeVisible();
-    await page.waitForTimeout(500);
     await snapshot(page, 'Material result negative');
   });
 });

--- a/tests/end-to-end/places.test.ts
+++ b/tests/end-to-end/places.test.ts
@@ -30,7 +30,6 @@ describeEndToEndTest('Places', () => {
     await page.waitForRequest(LOCATIONS_ENDPOINT);
     await expect(placesCount).toBeVisible();
     await expect(placeName).toBeVisible();
-    await page.waitForTimeout(500);
     await snapshot(page, 'Places list');
   });
 


### PR DESCRIPTION
Note: The snapshots won't update until after the next release due to the CDN public path reference for the CSS file, but it's been tested locally