### PR TITLE
Fix safari fab rendering issue

### DIFF
--- a/src/components/control/Fab/Fab.css
+++ b/src/components/control/Fab/Fab.css
@@ -3,7 +3,7 @@ locator-fab {
   display: flex;
   justify-content: center;
   pointer-events: none;
-  position: fixed;
+  position: absolute;
   width: 100%;
   z-index: 1;
 
@@ -16,7 +16,10 @@ locator-fab {
 
   &[position='top'] {
     bottom: unset;
-    position: absolute;
     top: var(--diamond-spacing);
+  }
+
+  &[sticky] {
+    position: fixed;
   }
 }

--- a/src/components/control/Fab/Fab.tsx
+++ b/src/components/control/Fab/Fab.tsx
@@ -5,6 +5,10 @@ export interface FabAttributes {
    * Where to place the button, if no position is given it will be placed at the bottom
    */
   position?: 'top';
+  /**
+   * If the button should scroll with the page
+   */
+  sticky?: boolean;
 }
 
 declare module 'react' {

--- a/src/pages/[postcode]/places/places.page.tsx
+++ b/src/pages/[postcode]/places/places.page.tsx
@@ -227,7 +227,7 @@ export default function PlacesPage() {
         </Suspense>
       </section>
       <diamond-enter type="fade" delay={0.25}>
-        <locator-fab>
+        <locator-fab sticky>
           <diamond-button size="sm" variant="primary">
             <Link to={`/${postcode}/places/map`}>
               <locator-icon icon="map"></locator-icon>

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -6,6 +6,7 @@
 
 article {
   container-type: inline-size;
+  position: relative;
 }
 
 .recycling-locator-variant-widget {


### PR DESCRIPTION
Fixes a couple of weird Safari only rendering issues with the FAB button:

- On the list view the FAB was displaying in a random position on the page
- On the map it was disappearing when the map loaded

In both cases, the button was still clickable at the original position, so it's only the browser rendering the visual part of the button in a different place 🥴