### PR TITLE
Fix duplicate scheme names

### DIFF
--- a/src/lib/getPropertyDisplayName.ts
+++ b/src/lib/getPropertyDisplayName.ts
@@ -34,8 +34,8 @@ export default function getPropertyDisplayName(
 
   if (dryScheme?.name === PROPERTY_TYPE.ALL) {
     // Avoid displaying "All properties" as the display name if we can help it
-    return filteredSchemes[0]?.name;
+    return filteredSchemes[0]?.name ?? property[0]?.name;
   }
 
-  return dryScheme?.name ?? property[0].name;
+  return dryScheme?.name ?? filteredSchemes[0]?.name ?? property[0]?.name;
 }

--- a/src/lib/getPropertyDisplayName.ts
+++ b/src/lib/getPropertyDisplayName.ts
@@ -1,20 +1,40 @@
-import { LocalAuthorityProperty } from '@/types/locatorApi';
+import {
+  LocalAuthority,
+  LocalAuthorityProperty as LAProperty,
+} from '@/types/locatorApi';
 
 import getPropertyTypeEnum from './getPropertyTypeEnum';
+
+function filterAllProperties(
+  property: LAProperty[],
+  allProperties: LAProperty[],
+) {
+  return property.filter(
+    (scheme) =>
+      !allProperties.some((allScheme) => allScheme.name === scheme.name),
+  );
+}
 
 /**
  * If there's a dry scheme return its name
  * otherwise return the name of the first scheme
  */
 export default function getPropertyDisplayName(
-  property: LocalAuthorityProperty[],
+  properties: LocalAuthority['properties'],
+  propertyType: string,
 ): string {
   const PROPERTY_TYPE = getPropertyTypeEnum();
-  const dryScheme = property.find((scheme) => scheme.type === 'Dry');
+  const property = properties[propertyType] as LAProperty[];
+  const allProperties = properties[PROPERTY_TYPE.ALL] as LAProperty[];
+  const filteredSchemes =
+    allProperties && propertyType !== PROPERTY_TYPE.ALL
+      ? filterAllProperties(allProperties, property)
+      : property;
+  const dryScheme = filteredSchemes.find((scheme) => scheme.type === 'Dry');
 
   if (dryScheme?.name === PROPERTY_TYPE.ALL) {
-    // Avoid displaying "All properties" as the display name if we can help
-    return property[0]?.name;
+    // Avoid displaying "All properties" as the display name if we can help it
+    return filteredSchemes[0]?.name;
   }
 
   return dryScheme?.name ?? property[0].name;

--- a/src/lib/getPropertyDisplayName.ts
+++ b/src/lib/getPropertyDisplayName.ts
@@ -28,7 +28,7 @@ export default function getPropertyDisplayName(
   const allProperties = properties[PROPERTY_TYPE.ALL] as LAProperty[];
   const filteredSchemes =
     allProperties && propertyType !== PROPERTY_TYPE.ALL
-      ? filterAllProperties(allProperties, property)
+      ? filterAllProperties(property, allProperties)
       : property;
   const dryScheme = filteredSchemes.find((scheme) => scheme.type === 'Dry');
 

--- a/src/pages/[postcode]/home/collection.page.tsx
+++ b/src/pages/[postcode]/home/collection.page.tsx
@@ -102,7 +102,7 @@ export default function CollectionPage() {
                 <summary onClick={() => (menuOpen.value = !menuOpen.value)}>
                   {menuOpen.value
                     ? 'Collections in this area'
-                    : getPropertyDisplayName(property)}
+                    : getPropertyDisplayName(properties, propertyType)}
                   <locator-icon icon="expand" />
                 </summary>
                 <nav>
@@ -114,7 +114,7 @@ export default function CollectionPage() {
                         >
                           <diamond-grid align-items="center" gap="xs">
                             <diamond-grid-item grow shrink>
-                              {getPropertyDisplayName(properties[type])}
+                              {getPropertyDisplayName(properties, type)}
                             </diamond-grid-item>
                             <diamond-grid-item>
                               <locator-icon icon="arrow-right" />
@@ -129,7 +129,7 @@ export default function CollectionPage() {
             </locator-details>
           ) : (
             <span className="diamond-text-weight-bold">
-              {getPropertyDisplayName(property)}
+              {getPropertyDisplayName(properties, propertyType)}
             </span>
           )}
         </locator-context-header>

--- a/src/pages/[postcode]/home/home.page.tsx
+++ b/src/pages/[postcode]/home/home.page.tsx
@@ -31,7 +31,7 @@ export default function HomeRecyclingPage() {
           >
             <diamond-card className="diamond-spacing-bottom-md" border radius>
               <h4 className="diamond-spacing-bottom-md">
-                {getPropertyDisplayName(property)}
+                {getPropertyDisplayName(properties, propertyType)}
               </h4>
               <SchemeContainerSummary containers={containers} limit={3} />
             </diamond-card>

--- a/src/pages/[postcode]/material/RecycleAtHome.tsx
+++ b/src/pages/[postcode]/material/RecycleAtHome.tsx
@@ -63,7 +63,7 @@ function ManyProperties({
                       color={recyclable ? 'positive' : 'negative'}
                     ></locator-icon>
                   </locator-icon-circle>
-                  {getPropertyDisplayName(allProperties[propertyType])}
+                  {getPropertyDisplayName(allProperties, propertyType)}
                 </Link>
               </locator-icon-link>
             </li>

--- a/tests/unit/getPropertyDisplayName.test.ts
+++ b/tests/unit/getPropertyDisplayName.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from 'vitest';
 
+import { LocalAuthorityResponse } from '../mocks/localAuthority';
 import getPropertyDisplayName from '@/lib/getPropertyDisplayName';
 import { LocalAuthority, PROPERTY_TYPE_EN } from '@/types/locatorApi';
 
@@ -76,42 +77,45 @@ test('Returns the first scheme name if the dry scheme is named all properties', 
 });
 
 test('Returns the scheme name not associated with all properties', () => {
-  const properties = {
-    [PROPERTY_TYPE_EN.ALL]: [
-      {
-        name: 'Some scheme',
-        type: 'Food',
-      },
-      {
-        name: 'All properties dry',
-        type: 'Dry',
-      },
-      {
-        name: 'Communal collections',
-        type: 'Food',
-      },
-    ],
-    [PROPERTY_TYPE_EN.KERBSIDE]: [
-      {
-        name: 'Another scheme',
-        type: 'Food',
-      },
-      {
-        name: 'Some scheme',
-        type: 'Food',
-      },
-      {
-        name: 'All properties dry',
-        type: 'Dry',
-      },
-      {
-        name: 'Communal collections',
-        type: 'Food',
-      },
-    ],
-  } as LocalAuthority['properties'];
+  const mockedLaResponse = {
+    ...LocalAuthorityResponse,
+    properties: {
+      ...LocalAuthorityResponse.properties,
+      [PROPERTY_TYPE_EN.NARROW_ACCESS]: [
+        ...LocalAuthorityResponse.properties[PROPERTY_TYPE_EN.ALL],
+        {
+          name: 'Fake scheme',
+          type: 'Dry',
+          containers: [
+            {
+              name: 'Box',
+              displayName: 'Box (35 to 60L)',
+              bodyColour: '#4f4f4f',
+              lidColour: '#4f4f4f',
+              notes: ['containers can be black or green.'],
+              materials: [
+                {
+                  id: 1000,
+                  name: 'Fake material',
+                  popular: false,
+                  category: {
+                    id: 7,
+                    name: 'Plastic bottles',
+                    popular: false,
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  } as LocalAuthority;
 
-  expect(getPropertyDisplayName(properties, PROPERTY_TYPE_EN.KERBSIDE)).toEqual(
-    'Another scheme',
-  );
+  expect(
+    getPropertyDisplayName(
+      mockedLaResponse.properties,
+      PROPERTY_TYPE_EN.NARROW_ACCESS,
+    ),
+  ).toEqual('Fake scheme');
 });

--- a/tests/unit/getPropertyDisplayName.test.ts
+++ b/tests/unit/getPropertyDisplayName.test.ts
@@ -22,7 +22,7 @@ test('Returns the first dry scheme name if there is one', () => {
     ],
   } as LocalAuthority['properties'];
 
-  expect(getPropertyDisplayName(properties[PROPERTY_TYPE_EN.ALL])).toEqual(
+  expect(getPropertyDisplayName(properties, PROPERTY_TYPE_EN.ALL)).toEqual(
     drySchemeName,
   );
 });
@@ -46,7 +46,7 @@ test('Returns the first scheme name if there is no dry scheme', () => {
     ],
   } as LocalAuthority['properties'];
 
-  expect(getPropertyDisplayName(properties[PROPERTY_TYPE_EN.ALL])).toEqual(
+  expect(getPropertyDisplayName(properties, PROPERTY_TYPE_EN.ALL)).toEqual(
     firstSchemeName,
   );
 });
@@ -70,7 +70,48 @@ test('Returns the first scheme name if the dry scheme is named all properties', 
     ],
   } as LocalAuthority['properties'];
 
-  expect(getPropertyDisplayName(properties[PROPERTY_TYPE_EN.ALL])).toEqual(
+  expect(getPropertyDisplayName(properties, PROPERTY_TYPE_EN.ALL)).toEqual(
     firstSchemeName,
+  );
+});
+
+test('Returns the scheme name not associated with all properties', () => {
+  const properties = {
+    [PROPERTY_TYPE_EN.ALL]: [
+      {
+        name: 'Some scheme',
+        type: 'Food',
+      },
+      {
+        name: 'All properties dry',
+        type: 'Dry',
+      },
+      {
+        name: 'Communal collections',
+        type: 'Food',
+      },
+    ],
+    [PROPERTY_TYPE_EN.KERBSIDE]: [
+      {
+        name: 'Another scheme',
+        type: 'Food',
+      },
+      {
+        name: 'Some scheme',
+        type: 'Food',
+      },
+      {
+        name: 'All properties dry',
+        type: 'Dry',
+      },
+      {
+        name: 'Communal collections',
+        type: 'Food',
+      },
+    ],
+  } as LocalAuthority['properties'];
+
+  expect(getPropertyDisplayName(properties, PROPERTY_TYPE_EN.KERBSIDE)).toEqual(
+    'Another scheme',
   );
 });


### PR DESCRIPTION
Avoids the potential of showing a duplicate scheme name given a non-all-properties-property-type by filtering out the schemes from the list that are included under the all properties property type.