### PR TITLE
Minor enhancement feedback round 2

### DIFF
--- a/src/components/composition/BorderedList/BorderedList.css
+++ b/src/components/composition/BorderedList/BorderedList.css
@@ -1,4 +1,5 @@
 locator-bordered-list {
+  --_item-padding: var(--diamond-spacing);
   display: block;
 
   > h2,
@@ -26,7 +27,7 @@ locator-bordered-list {
   > ul > li,
   > dl > div {
     border-top: var(--diamond-border);
-    padding-block: var(--diamond-spacing);
+    padding-block: var(--_item-padding);
   }
 
   > dl > div > dt {
@@ -35,6 +36,15 @@ locator-bordered-list {
 
   > dl > div > dd {
     margin: 0;
+  }
+
+  > nav > ul > li a,
+  > ul > li a,
+  > dl > div > dd a {
+    display: flex;
+    margin-block: calc(var(--_item-padding) * -1);
+    padding-block: var(--_item-padding);
+    width: 100%;
   }
 
   a {
@@ -48,10 +58,6 @@ locator-bordered-list {
   }
 
   &[size='sm'] {
-    > nav > ul > li,
-    > ul > li,
-    > dl > div {
-      padding-block: var(--diamond-spacing-sm);
-    }
+    --_item-padding: var(--diamond-spacing-sm);
   }
 }

--- a/src/components/content/PlaceSummary/PlaceSummary.css
+++ b/src/components/content/PlaceSummary/PlaceSummary.css
@@ -35,7 +35,7 @@ locator-place-summary {
   }
 
   dt {
-    font-weight: var(--diamond-font-weight-bold);
+    font-weight: var(--diamond-font-weight-normal);
     position: relative;
 
     &:not(:last-child) {

--- a/src/components/control/PlacesMap/PlacesMap.tsx
+++ b/src/components/control/PlacesMap/PlacesMap.tsx
@@ -44,6 +44,7 @@ export default class PlacesMap extends Component<PlacesMapProps> {
   MarkerGroup: H.map.Group;
   elementRef = createRef<HTMLDivElement>();
   currentZoom: number;
+  enableZoomEvent: boolean;
 
   resizeMap() {
     this.MapInstance?.getViewPort().resize();
@@ -105,7 +106,9 @@ export default class PlacesMap extends Component<PlacesMapProps> {
           this.currentZoom = newZoom;
         } else if (newZoom !== currentZoom) {
           this.currentZoom = newZoom;
-          this.props?.onZoom?.(newZoom);
+          if (this.enableZoomEvent) {
+            this.props?.onZoom?.(newZoom);
+          }
         }
       });
     } catch (error) {
@@ -157,6 +160,9 @@ export default class PlacesMap extends Component<PlacesMapProps> {
     this.MarkerGroup.removeAll();
 
     if (locations.length > 0) {
+      // Temporarily disable the zoom event to stop it firing when the lookAtData changes
+      this.enableZoomEvent = false;
+
       // Create the markers
       this.MarkerGroup.addObjects(
         locations.map((location) => this.addMarker(location)),
@@ -166,6 +172,10 @@ export default class PlacesMap extends Component<PlacesMapProps> {
       this.MapInstance.getViewModel().setLookAtData({
         bounds: this.MarkerGroup.getBoundingBox(),
       });
+
+      setTimeout(() => {
+        this.enableZoomEvent = true;
+      }, 500);
     }
   }
 

--- a/src/pages/[postcode]/home/collection.page.tsx
+++ b/src/pages/[postcode]/home/collection.page.tsx
@@ -74,7 +74,7 @@ export default function CollectionPage() {
       <div slot="layout-header">
         <locator-header>
           <locator-header-logo>
-            <Link to="/">
+            <Link to={`/${postcode}`}>
               <locator-logo type="logo-only"></locator-logo>
             </Link>
           </locator-header-logo>

--- a/src/pages/[postcode]/home/home.layout.tsx
+++ b/src/pages/[postcode]/home/home.layout.tsx
@@ -36,7 +36,9 @@ export default function HomeRecyclingLayout({
       <locator-header slot="layout-header">
         {open.value ? (
           <locator-header-content>
-            <locator-logo></locator-logo>
+            <Link to={`/${postcode}`}>
+              <locator-logo></locator-logo>
+            </Link>
             <diamond-button width="square" size="sm">
               <button
                 type="button"
@@ -55,7 +57,7 @@ export default function HomeRecyclingLayout({
         ) : (
           <>
             <locator-header-logo>
-              <Link to="/">
+              <Link to={`/${postcode}`}>
                 <locator-logo type="logo-only"></locator-logo>
               </Link>
             </locator-header-logo>

--- a/src/pages/[postcode]/material/material.layout.tsx
+++ b/src/pages/[postcode]/material/material.layout.tsx
@@ -48,7 +48,7 @@ export default function MaterialLayout() {
     <locator-layout>
       <locator-header slot="layout-header">
         <locator-header-logo>
-          <Link to="/">
+          <Link to={`/${postcode}`}>
             <locator-logo type="logo-only"></locator-logo>
           </Link>
         </locator-header-logo>

--- a/src/pages/[postcode]/places/place/place.layout.tsx
+++ b/src/pages/[postcode]/places/place/place.layout.tsx
@@ -41,7 +41,7 @@ export default function PlaceLayout({
     <locator-layout>
       <locator-header slot="layout-header">
         <locator-header-logo>
-          <Link to="/">
+          <Link to={`/${postcode}`}>
             <locator-logo type="logo-only"></locator-logo>
           </Link>
         </locator-header-logo>

--- a/src/pages/[postcode]/places/places.layout.tsx
+++ b/src/pages/[postcode]/places/places.layout.tsx
@@ -48,7 +48,9 @@ export default function PlacesLayout({
       <locator-header slot="layout-header">
         {open.value ? (
           <locator-header-content>
-            <locator-logo></locator-logo>
+            <Link to={`/${postcode}`}>
+              <locator-logo></locator-logo>
+            </Link>
             <diamond-button width="square" size="sm">
               <button
                 type="button"
@@ -67,7 +69,7 @@ export default function PlacesLayout({
         ) : (
           <>
             <locator-header-logo>
-              <Link to="/">
+              <Link to={`/${postcode}`}>
                 <locator-logo type="logo-only"></locator-logo>
               </Link>
             </locator-header-logo>

--- a/src/pages/[postcode]/places/places.page.tsx
+++ b/src/pages/[postcode]/places/places.page.tsx
@@ -196,17 +196,15 @@ export default function PlacesPage() {
   }, [materialName]);
 
   return (
-    <>
+    <locator-wrap max-width="none" gutter="fluid">
       <diamond-section padding="md">
-        <locator-wrap max-width="none" gutter="fluid">
-          <section className="diamond-spacing-bottom-lg">
-            <Suspense fallback={<Loading />}>
-              <Await resolve={data}>
-                <Places />
-              </Await>
-            </Suspense>
-          </section>
-        </locator-wrap>
+        <section className="diamond-spacing-bottom-lg">
+          <Suspense fallback={<Loading />}>
+            <Await resolve={data}>
+              <Places />
+            </Await>
+          </Suspense>
+        </section>
       </diamond-section>
       <section>
         <Suspense fallback={null}>
@@ -236,6 +234,6 @@ export default function PlacesPage() {
           </diamond-button>
         </locator-fab>
       </diamond-enter>
-    </>
+    </locator-wrap>
   );
 }

--- a/src/pages/[postcode]/places/search/search.layout.tsx
+++ b/src/pages/[postcode]/places/search/search.layout.tsx
@@ -35,7 +35,7 @@ export default function PlacesSearchLayout({
     <locator-layout>
       <locator-header slot="layout-header">
         <locator-header-logo>
-          <Link to="/">
+          <Link to={`/${postcode}`}>
             <locator-logo type="logo-only"></locator-logo>
           </Link>
         </locator-header-logo>


### PR DESCRIPTION
- [WRAP-477 : \[Marker.io\] 'Home' link](https://linear.app/etch/issue/WRAP-477/[markerio]-home-link)
- [[WRAP-492 : Popular searches – link target area](https://linear.app/etch/issue/WRAP-492/popular-searches-link-target-area)](https://linear.app/etch/issue/WRAP-492/popular-searches-link-target-area)
- [[WRAP-488 : Home Recycling – Scheme order](https://linear.app/etch/issue/WRAP-488/home-recycling-scheme-order)](https://linear.app/etch/issue/WRAP-488/home-recycling-scheme-order)
- [[WRAP-493 : Place summary – bolding is back to front](https://linear.app/etch/issue/WRAP-493/place-summary-bolding-is-back-to-front)](https://linear.app/etch/issue/WRAP-493/place-summary-bolding-is-back-to-front)
- [[WRAP-494 : Places list – tip spacing should match the list](https://linear.app/etch/issue/WRAP-494/places-list-tip-spacing-should-match-the-list)](https://linear.app/etch/issue/WRAP-494/places-list-tip-spacing-should-match-the-list)
- [[WRAP-490 : Places map – search this area – adjust tolerance](https://linear.app/etch/issue/WRAP-490/places-map-search-this-area-adjust-tolerance)](https://linear.app/etch/issue/WRAP-490/places-map-search-this-area-adjust-tolerance)