### PR TITLE
Fix recycling locator element type for React

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -87,9 +87,19 @@ register(
   },
 );
 
+type RecyclingLocatorElement = EventSource &
+  CustomElement<RecyclingLocatorAttributes>;
+
 declare global {
   interface HTMLElementTagNameMap {
-    'recycling-locator': EventSource &
-      CustomElement<RecyclingLocatorAttributes>;
+    'recycling-locator': RecyclingLocatorElement;
+  }
+}
+
+declare module 'react' {
+  namespace JSX {
+    interface IntrinsicElements {
+      'recycling-locator': RecyclingLocatorElement;
+    }
   }
 }


### PR DESCRIPTION
Adds a global type for the recycling-locator custom element that's compatible with React projects (JSX)