### PR TITLE
Fix missing background

### DIFF
--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -5,6 +5,7 @@
 @import './utils.css';
 
 article {
+  background: var(--diamond-theme-background);
   container-type: inline-size;
   overflow-y: auto;
   position: relative;


### PR DESCRIPTION
A small fix which adds a background colour to the whole locator.

Without this, in some places, the websites background colour will leak through into the locator UI. This is only visible when the background colour isn't white (unlike the demo site).