### PR TITLE
Loading improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "storybook:start": "storybook dev -p 6006",
     "storybook:build": "storybook build",
     "test": "vitest --ui",
-    "test:ci": "percy exec -- vitest",
+    "test:ci": "vitest",
     "test:unit": "vitest --ui unit",
     "test:end-to-end": "VITE_TEST=true npm run build && vitest --ui end-to-end",
     "test:end-to-end-debug": "DEBUG=pw:api PWDEBUG=console vitest --ui"

--- a/public/translations/cy.json
+++ b/public/translations/cy.json
@@ -205,12 +205,8 @@
       "contact": "Cysylltu"
     },
     "aside": {
-      "paragraph": "Cysylltwch â’r darparwr gwasanaeth hwn os oes angen ichi:",
-      "list": [
-        "Ddweud am gasgliad a fethwyd",
-        "Archebu biniau ychwanegol",
-        "Trefnu casgliad ar gyfer eitemau mawr neu swmpus"
-      ]
+      "title": "Angen help gyda'ch ailgylchu cartref?",
+      "content": "Cysylltwch â’r darparwr gwasanaeth hwn os oes angen ichi ddweud am gasgliad a fethwyd, archebu biniau ychwanegol neu trefnu casgliad ar gyfer eitemau mawr neu swmpus"
     },
     "collections": {
       "title": "Gwiriwch beth allwch ei roi yn eich ailgylchu gartref.",

--- a/public/translations/en.json
+++ b/public/translations/en.json
@@ -203,12 +203,8 @@
       "contact": "Contact"
     },
     "aside": {
-      "paragraph": "Contact this service provider if you need to:",
-      "list": [
-        "Report a missed collection",
-        "Order additional bins",
-        "Arrange collection of large or bulky items"
-      ]
+      "title": "Need help with your home recycling?",
+      "content": "Contact this service provider if you need to report a missed collection, order additional bins or arrange collection of large or bulky items"
     },
     "collections": {
       "title": "Check what you can put in your home recycling.",

--- a/src/components/canvas/ContextHeader/ContextHeader.css
+++ b/src/components/canvas/ContextHeader/ContextHeader.css
@@ -10,7 +10,7 @@ locator-context-header {
   position: sticky;
   top: var(--header-height);
   transition: color var(--diamond-transition);
-  z-index: 1;
+  z-index: var(--layer-two);
 
   @container (width > 768px) {
     top: 0;

--- a/src/components/composition/Layout/Layout.css
+++ b/src/components/composition/Layout/Layout.css
@@ -77,7 +77,7 @@ locator-layout {
     grid-area: header;
     position: sticky;
     top: 0;
-    z-index: 2;
+    z-index: var(--layer-two);
   }
 
   &::part(main) {

--- a/src/components/control/Fab/Fab.css
+++ b/src/components/control/Fab/Fab.css
@@ -6,7 +6,7 @@ locator-fab {
   pointer-events: none;
   position: absolute;
   width: 100%;
-  z-index: 1;
+  z-index: var(--layer-one);
 
   diamond-button {
     --diamond-button-padding-block: var(--diamond-spacing-xs);

--- a/src/components/control/MaterialSearchInput/MaterialSearchInput.css
+++ b/src/components/control/MaterialSearchInput/MaterialSearchInput.css
@@ -61,7 +61,7 @@ locator-material-search-input {
     position: absolute;
     top: 100%;
     width: 100%;
-    z-index: 1;
+    z-index: var(--layer-one);
 
     &[data-headlessui-state='open'] {
       display: block;

--- a/src/components/control/NavBar/NavBar.css
+++ b/src/components/control/NavBar/NavBar.css
@@ -4,7 +4,7 @@ locator-nav-bar {
   display: block;
   position: sticky;
   top: calc(var(--header-height) + 1px);
-  z-index: 1;
+  z-index: var(--layer-two);
 
   locator-layout:not(:has([slot='layout-aside'])) & {
     top: 0;

--- a/src/components/template/TipContent/TipContent.tsx
+++ b/src/components/template/TipContent/TipContent.tsx
@@ -8,9 +8,13 @@ export default function TipContent({
   tip,
   ctaWidth = 'full-width',
 }: {
-  readonly tip: RecyclingMeta;
+  readonly tip?: RecyclingMeta;
   readonly ctaWidth?: 'full-width' | 'full-width-mobile';
 }) {
+  if (!tip) {
+    return null;
+  }
+
   return (
     <diamond-enter type="fade">
       <p className="diamond-text-weight-bold">{tip.subtitle}</p>

--- a/src/lib/getTip.ts
+++ b/src/lib/getTip.ts
@@ -1,6 +1,9 @@
+import * as Sentry from '@sentry/browser';
 import random from 'lodash/random';
 
 import { RecyclingMeta } from '@/types/locatorApi';
+
+import LocatorApi from './LocatorApi';
 
 /**
  * Get a tip for a material or path, falling back to a random generic tip
@@ -29,4 +32,34 @@ export default function getTip(
   }
 
   return tips[random(0, tips.length - 1)];
+}
+
+/**
+ * Log and ignore all tip errors because not having the content isn't a blocker
+ */
+function handleTipError(error: Error) {
+  Sentry.captureException(error, {
+    tags: { route: 'Get tip' },
+  });
+  return Promise.resolve(null);
+}
+
+export async function getTipByPath(path: string) {
+  try {
+    const meta = await LocatorApi.get<RecyclingMeta[]>('recycling-meta');
+    return getTip(meta, { path });
+  } catch (error) {
+    handleTipError(error);
+  }
+}
+
+export async function getTipByMaterial(materialId: string) {
+  try {
+    const meta = await LocatorApi.get<RecyclingMeta[]>(
+      'recycling-meta?categories=HINT',
+    );
+    return getTip(meta, { materialId });
+  } catch (error) {
+    handleTipError(error);
+  }
 }

--- a/src/lib/sortPropertyTypes.ts
+++ b/src/lib/sortPropertyTypes.ts
@@ -1,0 +1,25 @@
+import { LocalAuthority } from '@/types/locatorApi';
+
+import getPropertyTypeEnum from './getPropertyTypeEnum';
+
+export default function sortPropertyTypes(
+  properties: LocalAuthority['properties'],
+) {
+  const PROPERTY_TYPE = getPropertyTypeEnum();
+  const sortOrder = [
+    PROPERTY_TYPE.KERBSIDE,
+    PROPERTY_TYPE.FLATS_WITH_INDIVIDUAL_BINS,
+    PROPERTY_TYPE.FLATS_WITH_COMMUNAL_BINS,
+    PROPERTY_TYPE.NARROW_ACCESS,
+    PROPERTY_TYPE.ALL,
+  ] as string[];
+
+  return Object.keys(properties)
+    .toSorted((a, b) => {
+      return sortOrder.indexOf(a) - sortOrder.indexOf(b);
+    })
+    .reduce((sorted, propertyType) => {
+      sorted[propertyType] = properties[propertyType];
+      return sorted;
+    }, {});
+}

--- a/src/lib/useScrollRestoration.ts
+++ b/src/lib/useScrollRestoration.ts
@@ -1,0 +1,26 @@
+import { useEffect } from 'preact/hooks';
+import { useLocation, useNavigation } from 'react-router-dom';
+
+/**
+ * Restores the scroll position of the main content area when navigating between
+ * The scroll area being placed on the shadow dom part makes this extra difficult
+ * https://github.com/remix-run/react-router/pull/10468
+ */
+export default function useScrollRestoration(
+  container: React.RefObject<HTMLElement>,
+) {
+  const { key } = useLocation();
+  const { state } = useNavigation();
+
+  useEffect(() => {
+    if (state !== 'idle') {
+      return;
+    }
+
+    container.current
+      ?.closest('locator-layout')
+      ?.shadowRoot?.querySelector('[part="main"]')
+      ?.scrollTo(0, 0);
+    container.current?.closest('article')?.scrollTo(0, 0);
+  }, [key, state, container]);
+}

--- a/src/pages/[postcode]/home/collection.loader.ts
+++ b/src/pages/[postcode]/home/collection.loader.ts
@@ -1,32 +1,13 @@
-import * as Sentry from '@sentry/browser';
 import { defer } from 'react-router-dom';
 
-import LocatorApi from '@/lib/LocatorApi';
-import getTip from '@/lib/getTip';
+import { getTipByPath } from '@/lib/getTip';
 import { RecyclingMeta } from '@/types/locatorApi';
 
 export interface HomeCollectionLoaderResponse {
-  tip?: RecyclingMeta;
-}
-
-async function getData(): Promise<HomeCollectionLoaderResponse> {
-  try {
-    const meta = await LocatorApi.get<RecyclingMeta[]>(
-      'recycling-meta?categories=HINT',
-    );
-
-    return {
-      tip: getTip(meta, { path: '/:postcode/home/collection' }),
-    };
-  } catch (error) {
-    Sentry.captureException(error, {
-      tags: { route: 'Home collection loader' },
-    });
-    // Let the user carry on without the tip
-    return Promise.resolve({ tip: null });
-  }
+  tip?: Promise<RecyclingMeta>;
 }
 
 export default function homeCollectionLoader() {
-  return defer({ data: getData() });
+  const tip = getTipByPath('/:postcode/home/collection');
+  return defer({ tip });
 }

--- a/src/pages/[postcode]/home/collection.page.tsx
+++ b/src/pages/[postcode]/home/collection.page.tsx
@@ -54,6 +54,9 @@ function CollectionPageContent({
   const propertyType = searchParams.get('propertyType') ?? propertyTypes[0];
   const menuOpen = useSignal(false);
   const property = properties[propertyType];
+  const isLoadingNewPath =
+    navigation.state === 'loading' &&
+    !navigation.location?.search.includes(propertyType.replace(' ', '+'));
 
   useEffect(() => {
     if (search) {
@@ -79,7 +82,7 @@ function CollectionPageContent({
             <details ref={menuRef}>
               {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
               <summary onClick={() => (menuOpen.value = !menuOpen.value)}>
-                {menuOpen.value || navigation.state === 'loading'
+                {menuOpen.value || isLoadingNewPath
                   ? 'Collections in this area'
                   : propertyType}
                 <locator-icon icon="expand" />
@@ -112,7 +115,7 @@ function CollectionPageContent({
           <span className="diamond-text-weight-bold">{propertyType}</span>
         )}
       </locator-context-header>
-      {navigation.state !== 'loading' && (
+      {!isLoadingNewPath && (
         <diamond-enter type="fade">
           <diamond-section padding="lg">
             <locator-wrap>

--- a/src/pages/[postcode]/home/contact.page.tsx
+++ b/src/pages/[postcode]/home/contact.page.tsx
@@ -1,17 +1,23 @@
+import { Suspense } from 'preact/compat';
 import { useTranslation } from 'react-i18next';
+import { Await } from 'react-router-dom';
+import '@etchteam/diamond-ui/composition/Enter/Enter';
 
 import '@/components/composition/BorderedList/BorderedList';
+import { LocalAuthority } from '@/types/locatorApi';
 
 import { useHomeRecyclingLoaderData } from './home.loader';
 
-export default function HomeRecyclingPage() {
+function HomeRecyclingContactPageContent({
+  localAuthority,
+}: {
+  readonly localAuthority: LocalAuthority;
+}) {
   const { t } = useTranslation();
-  const { localAuthority } = useHomeRecyclingLoaderData();
   const tContext = 'homeRecycling.contact';
 
   return (
-    <>
-      <h3 className="diamond-spacing-bottom-md">{t(`${tContext}.title`)}</h3>
+    <diamond-enter type="fade">
       <locator-bordered-list size="sm">
         <h4 className="text-color-muted">{localAuthority.name}</h4>
         <dl>
@@ -54,6 +60,27 @@ export default function HomeRecyclingPage() {
           )}
         </span>
       </div>
+    </diamond-enter>
+  );
+}
+
+export default function HomeRecyclingContactPage() {
+  const { t } = useTranslation();
+  const { localAuthority: localAuthorityPromise } =
+    useHomeRecyclingLoaderData();
+
+  return (
+    <>
+      <h3 className="diamond-spacing-bottom-md">
+        {t(`homeRecycling.contact.title`)}
+      </h3>
+      <Suspense fallback={/* hitting loading here is unexpected */ null}>
+        <Await resolve={localAuthorityPromise}>
+          {(localAuthority) => (
+            <HomeRecyclingContactPageContent localAuthority={localAuthority} />
+          )}
+        </Await>
+      </Suspense>
     </>
   );
 }

--- a/src/pages/[postcode]/home/home.loader.ts
+++ b/src/pages/[postcode]/home/home.loader.ts
@@ -1,44 +1,23 @@
-import { LoaderFunctionArgs, useRouteLoaderData } from 'react-router-dom';
+import {
+  LoaderFunctionArgs,
+  defer,
+  useRouteLoaderData,
+} from 'react-router-dom';
 
 import LocatorApi from '@/lib/LocatorApi';
-import getPropertyTypeEnum from '@/lib/getPropertyTypeEnum';
 import { LocalAuthority } from '@/types/locatorApi';
 
 export interface HomeRecyclingLoaderResponse {
-  localAuthority: LocalAuthority;
-  properties: LocalAuthority['properties'];
+  localAuthority: Promise<LocalAuthority>;
 }
 
-export default async function homeRecyclingLoader({
-  params,
-}: LoaderFunctionArgs) {
+export default function homeRecyclingLoader({ params }: LoaderFunctionArgs) {
   const postcode = params.postcode;
-  const PROPERTY_TYPE = getPropertyTypeEnum();
-  const localAuthority = await LocatorApi.get<LocalAuthority>(
+  const localAuthority = LocatorApi.get<LocalAuthority>(
     `local-authority/${postcode}`,
   );
 
-  const sortOrder = [
-    PROPERTY_TYPE.KERBSIDE,
-    PROPERTY_TYPE.FLATS_WITH_INDIVIDUAL_BINS,
-    PROPERTY_TYPE.FLATS_WITH_COMMUNAL_BINS,
-    PROPERTY_TYPE.NARROW_ACCESS,
-    PROPERTY_TYPE.ALL,
-  ] as string[];
-
-  const sortedProperties = Object.keys(localAuthority.properties)
-    .toSorted((a, b) => {
-      return sortOrder.indexOf(a) - sortOrder.indexOf(b);
-    })
-    .reduce((sorted, propertyType) => {
-      sorted[propertyType] = localAuthority.properties[propertyType];
-      return sorted;
-    }, {});
-
-  return {
-    localAuthority,
-    properties: sortedProperties,
-  };
+  return defer({ localAuthority });
 }
 
 export function useHomeRecyclingLoaderData() {

--- a/src/pages/[postcode]/home/home.page.tsx
+++ b/src/pages/[postcode]/home/home.page.tsx
@@ -1,23 +1,36 @@
+import { Suspense } from 'preact/compat';
 import { useTranslation } from 'react-i18next';
-import { Link, useParams } from 'react-router-dom';
+import { Await, Link, useParams } from 'react-router-dom';
+import '@etchteam/diamond-ui/composition/Enter/Enter';
 import '@etchteam/diamond-ui/canvas/Card/Card';
 
+import '@/components/canvas/LoadingCard/LoadingCard';
 import '@/components/content/Container/Container';
 import SchemeContainerSummary from '@/components/template/SchemeContainerSummary/SchemeContainerSummary';
+import sortPropertyTypes from '@/lib/sortPropertyTypes';
+import { LocalAuthority } from '@/types/locatorApi';
 
 import { useHomeRecyclingLoaderData } from './home.loader';
 
-export default function HomeRecyclingPage() {
-  const { t } = useTranslation();
+function Loading() {
+  return (
+    <diamond-enter type="fade-in-up">
+      <locator-loading-card />
+    </diamond-enter>
+  );
+}
+
+function PropertyList({
+  localAuthority,
+}: {
+  readonly localAuthority: LocalAuthority;
+}) {
   const { postcode } = useParams();
-  const { properties } = useHomeRecyclingLoaderData();
+  const properties = sortPropertyTypes(localAuthority.properties);
   const propertyTypes = Object.keys(properties);
 
   return (
-    <section className="diamond-spacing-bottom-lg">
-      <h3>{t('homeRecycling.collections.title')}</h3>
-      <p>{t('homeRecycling.collections.help')}</p>
-
+    <diamond-enter type="fade">
       {propertyTypes.map((propertyType) => {
         const safePropertyType = encodeURIComponent(propertyType);
         const property = properties[propertyType];
@@ -35,6 +48,24 @@ export default function HomeRecyclingPage() {
           </Link>
         );
       })}
+    </diamond-enter>
+  );
+}
+
+export default function HomeRecyclingPage() {
+  const { t } = useTranslation();
+  const { localAuthority } = useHomeRecyclingLoaderData();
+
+  return (
+    <section className="diamond-spacing-bottom-lg">
+      <h3>{t('homeRecycling.collections.title')}</h3>
+      <p>{t('homeRecycling.collections.help')}</p>
+
+      <Suspense fallback={<Loading />}>
+        <Await resolve={localAuthority}>
+          {(la) => <PropertyList localAuthority={la} />}
+        </Await>
+      </Suspense>
     </section>
   );
 }

--- a/src/pages/[postcode]/home/recycling-centre.loader.ts
+++ b/src/pages/[postcode]/home/recycling-centre.loader.ts
@@ -1,21 +1,19 @@
 import { LoaderFunctionArgs } from 'react-router-dom';
 
 import LocatorApi from '@/lib/LocatorApi';
-import { Location, LocationsResponse } from '@/types/locatorApi';
+import { LocationsResponse } from '@/types/locatorApi';
 
 export interface HomeRecyclingCentreLoaderResponse {
-  locations: Location[];
+  locations: Promise<LocationsResponse>;
 }
 
 export default async function homeRecyclingCentreLoader({
   params,
 }: LoaderFunctionArgs) {
   const postcode = params.postcode;
-  const locations = await LocatorApi.get<LocationsResponse>(
-    `locations/${postcode}`,
-  );
+  const locations = LocatorApi.get<LocationsResponse>(`locations/${postcode}`);
 
   return {
-    locations: locations.items,
+    locations: locations,
   };
 }

--- a/src/pages/[postcode]/home/recycling-centre.page.tsx
+++ b/src/pages/[postcode]/home/recycling-centre.page.tsx
@@ -1,5 +1,6 @@
+import { Suspense } from 'preact/compat';
 import { useTranslation } from 'react-i18next';
-import { Link, useLoaderData, useParams } from 'react-router-dom';
+import { Await, Link, useLoaderData, useParams } from 'react-router-dom';
 import '@etchteam/diamond-ui/canvas/Card/Card';
 import '@etchteam/diamond-ui/composition/Grid/Grid';
 import '@etchteam/diamond-ui/composition/Grid/GridItem';
@@ -9,14 +10,40 @@ import '@/components/composition/IconText/IconText';
 import '@/components/content/Icon/Icon';
 import Place from '@/components/template/Place/Place';
 import PostCodeResolver from '@/lib/PostcodeResolver';
+import { Location } from '@/types/locatorApi';
 
 import { HomeRecyclingCentreLoaderResponse } from './recycling-centre.loader';
 
-export default function HomeRecyclingCentrePage() {
+function Loading() {
+  const { t } = useTranslation();
+
+  return (
+    <>
+      <section className="diamond-spacing-bottom-lg">
+        <h3>{t('homeRecycling.hwrc.title')}</h3>
+        <diamond-enter type="fade-in-up">
+          <locator-loading-card />
+        </diamond-enter>
+      </section>
+      <section className="diamond-spacing-bottom-lg">
+        <h3 className="diamond-spacing-bottom-md">
+          {t('homeRecycling.hwrc.nearbyPlaces.title')}
+        </h3>
+        <diamond-enter type="fade-in-up">
+          <locator-loading-card />
+        </diamond-enter>
+      </section>
+    </>
+  );
+}
+
+function HomeRecyclingCentrePageContent({
+  locations,
+}: {
+  readonly locations: Location[];
+}) {
   const { t } = useTranslation();
   const { postcode } = useParams();
-  const { locations } = useLoaderData() as HomeRecyclingCentreLoaderResponse;
-  const tContext = 'homeRecycling.hwrc';
   const hwrcLocations = locations.filter((location) =>
     location.locations.some((l) => l.locationType === 'HWRC'),
   );
@@ -26,90 +53,113 @@ export default function HomeRecyclingCentrePage() {
   return (
     <>
       <section className="diamond-spacing-bottom-lg">
-        <h3>{t(`${tContext}.title`)}</h3>
-        <p>
-          {t(
-            `${tContext}.content${hwrcLocationsCount >= 30 ? 'ThirtyPlus' : ''}`,
-            { count: hwrcLocationsCount },
-          )}
-        </p>
-        {hwrcLocationsCount > 0 && (
-          <>
-            <diamond-card
-              className="theme-info diamond-spacing-bottom-md"
-              padding="sm"
-              radius
-            >
-              <locator-icon-text>
-                <locator-icon icon="info"></locator-icon>
-                <p className="diamond-text-size-sm">{t(`${tContext}.info`)}</p>
-              </locator-icon-text>
-            </diamond-card>
+        <h3>{t('homeRecycling.hwrc.title')}</h3>
 
-            {hwrcLocations.map((location) => {
-              const locationPostcode =
-                PostCodeResolver.extractPostcodeFromString(location.address);
-              const locationName = encodeURIComponent(location.name);
+        <diamond-enter type="fade">
+          <p>
+            {t(
+              `homeRecycling.hwrc.content${hwrcLocationsCount >= 30 ? 'ThirtyPlus' : ''}`,
+              { count: hwrcLocationsCount },
+            )}
+          </p>
+          {hwrcLocationsCount > 0 && (
+            <>
+              <diamond-card
+                className="theme-info diamond-spacing-bottom-md"
+                padding="sm"
+                radius
+              >
+                <locator-icon-text>
+                  <locator-icon icon="info"></locator-icon>
+                  <p className="diamond-text-size-sm">
+                    {t('homeRecycling.hwrc.info')}
+                  </p>
+                </locator-icon-text>
+              </diamond-card>
 
-              return (
-                <Link
-                  to={`/${postcode}/places/${locationName}/${locationPostcode}`}
-                  key={location.id}
-                >
-                  <diamond-card
-                    className="diamond-spacing-bottom-sm"
-                    border
-                    radius
+              {hwrcLocations.map((location) => {
+                const locationPostcode =
+                  PostCodeResolver.extractPostcodeFromString(location.address);
+                const locationName = encodeURIComponent(location.name);
+
+                return (
+                  <Link
+                    to={`/${postcode}/places/${locationName}/${locationPostcode}`}
+                    key={location.id}
                   >
-                    <Place location={location} />
-                  </diamond-card>
-                </Link>
-              );
-            })}
-          </>
-        )}
+                    <diamond-card
+                      className="diamond-spacing-bottom-sm"
+                      border
+                      radius
+                    >
+                      <Place location={location} />
+                    </diamond-card>
+                  </Link>
+                );
+              })}
+            </>
+          )}
+        </diamond-enter>
       </section>
 
       <section className="diamond-spacing-bottom-lg">
         <h3 className="diamond-spacing-bottom-md">
-          {t(`${tContext}.nearbyPlaces.title`)}
+          {t('homeRecycling.hwrc.nearbyPlaces.title')}
         </h3>
-        <diamond-card border radius>
-          <locator-icon-text className="diamond-spacing-bottom-md">
-            <locator-icon-circle
-              variant={otherLocationsCount === 0 ? 'negative' : 'positive'}
-            >
-              <locator-icon icon="place"></locator-icon>
-            </locator-icon-circle>
-            <h3>
-              {t(
-                `${tContext}.nearbyPlaces.content${otherLocationsCount >= 30 ? 'ThirtyPlus' : ''}`,
-                {
-                  count: otherLocationsCount,
-                },
-              )}
-            </h3>
-          </locator-icon-text>
-          <diamond-button width="full-width">
-            <diamond-grid>
-              <diamond-grid-item small-mobile="6">
-                <diamond-button width="full-width">
-                  <Link to={`/${postcode}/places`}>
-                    {t('actions.listPlaces')}
-                  </Link>
-                </diamond-button>
-              </diamond-grid-item>
-              <diamond-grid-item small-mobile="6">
-                <diamond-button width="full-width">
-                  <Link to={`/${postcode}/places/map`}>
-                    {t('actions.showMap')}
-                  </Link>
-                </diamond-button>
-              </diamond-grid-item>
-            </diamond-grid>
-          </diamond-button>
-        </diamond-card>
+
+        <diamond-enter type="fade">
+          <diamond-card border radius>
+            <locator-icon-text className="diamond-spacing-bottom-md">
+              <locator-icon-circle
+                variant={otherLocationsCount === 0 ? 'negative' : 'positive'}
+              >
+                <locator-icon icon="place"></locator-icon>
+              </locator-icon-circle>
+              <h3>
+                {t(
+                  `homeRecycling.hwrc.nearbyPlaces.content${otherLocationsCount >= 30 ? 'ThirtyPlus' : ''}`,
+                  {
+                    count: otherLocationsCount,
+                  },
+                )}
+              </h3>
+            </locator-icon-text>
+            <diamond-button width="full-width">
+              <diamond-grid>
+                <diamond-grid-item small-mobile="6">
+                  <diamond-button width="full-width">
+                    <Link to={`/${postcode}/places`}>
+                      {t('actions.listPlaces')}
+                    </Link>
+                  </diamond-button>
+                </diamond-grid-item>
+                <diamond-grid-item small-mobile="6">
+                  <diamond-button width="full-width">
+                    <Link to={`/${postcode}/places/map`}>
+                      {t('actions.showMap')}
+                    </Link>
+                  </diamond-button>
+                </diamond-grid-item>
+              </diamond-grid>
+            </diamond-button>
+          </diamond-card>
+        </diamond-enter>
       </section>
     </>
+  );
+}
+
+export default function HomeRecyclingCentrePage() {
+  const { locations: locationsPromise } =
+    useLoaderData() as HomeRecyclingCentreLoaderResponse;
+
+  return (
+    <Suspense fallback={<Loading />}>
+      <Await resolve={locationsPromise}>
+        {(locations) => (
+          <HomeRecyclingCentrePageContent locations={locations.items} />
+        )}
+      </Await>
+    </Suspense>
   );
 }

--- a/src/pages/[postcode]/material/RecycleAtHome.tsx
+++ b/src/pages/[postcode]/material/RecycleAtHome.tsx
@@ -176,7 +176,9 @@ export default function RecycleAtHome({
       )}
 
       <diamond-button width="full-width">
-        <Link to={`/${postcode}/home`}>{t(`material.recycleAtHome.cta`)}</Link>
+        <Link to={`/${postcode}/home`} unstable_viewTransition>
+          {t(`material.recycleAtHome.cta`)}
+        </Link>
       </diamond-button>
     </diamond-card>
   );

--- a/src/pages/[postcode]/material/material.layout.tsx
+++ b/src/pages/[postcode]/material/material.layout.tsx
@@ -1,13 +1,5 @@
-import { Suspense } from 'preact/compat';
-import { useEffect } from 'preact/hooks';
 import { useTranslation } from 'react-i18next';
-import {
-  Await,
-  Link,
-  Outlet,
-  useParams,
-  useSearchParams,
-} from 'react-router-dom';
+import { Link, Outlet, useParams } from 'react-router-dom';
 import '@etchteam/diamond-ui/control/Button/Button';
 import '@etchteam/diamond-ui/canvas/Section/Section';
 import '@etchteam/diamond-ui/composition/Grid/Grid';
@@ -20,29 +12,10 @@ import '@/components/canvas/Tip/Tip';
 import '@/components/composition/Wrap/Wrap';
 import '@/components/content/HeaderTitle/HeaderTitle';
 import '@/components/content/Icon/Icon';
-import TipContent from '@/components/template/TipContent/TipContent';
-import config from '@/config';
-import useAnalytics from '@/lib/useAnalytics';
-
-import { useMaterialLoaderData } from './material.loader';
 
 export default function MaterialLayout() {
   const { t } = useTranslation();
   const { postcode } = useParams();
-  const { recordEvent } = useAnalytics();
-  const { data } = useMaterialLoaderData();
-  const [searchParams] = useSearchParams();
-  const materialId = searchParams.get('id');
-  const materialName = searchParams.get('name');
-
-  useEffect(() => {
-    if (materialName) {
-      recordEvent({
-        category: 'MaterialResult::MaterialSearch',
-        action: materialName,
-      });
-    }
-  }, [materialName]);
 
   return (
     <locator-layout>
@@ -66,34 +39,7 @@ export default function MaterialLayout() {
           </locator-header-title>
         </locator-header-content>
       </locator-header>
-      <div slot="layout-main">
-        {materialId && (
-          <Link
-            to={`/${postcode}/material/search`}
-            className="diamond-text-decoration-none"
-          >
-            <locator-context-header>
-              <div className="diamond-text-weight-bold">{materialName}</div>
-              <locator-icon icon="search" color="primary" />
-            </locator-context-header>
-          </Link>
-        )}
-        <Outlet />
-      </div>
-      <locator-tip slot="layout-aside" text-align="center">
-        <locator-wrap>
-          <img
-            className="diamond-spacing-bottom-sm"
-            src={config.imagePath + 'material-tip.svg'}
-            alt=""
-          />
-          <Suspense fallback={null}>
-            <Await resolve={data}>
-              {({ tip }) => <TipContent tip={tip} />}
-            </Await>
-          </Suspense>
-        </locator-wrap>
-      </locator-tip>
+      <Outlet />
     </locator-layout>
   );
 }

--- a/src/pages/[postcode]/material/material.page.tsx
+++ b/src/pages/[postcode]/material/material.page.tsx
@@ -58,8 +58,10 @@ function MaterialPageContent({
     <diamond-enter type="fade">
       <locator-hero variant={recyclable ? 'positive' : 'negative'}>
         <locator-wrap>
-          <locator-icon icon={recyclable ? 'tick-circle' : 'cross-circle'} />
-          <h3>{t(`material.hero.${recyclable ? 'yes' : 'no'}`)}</h3>
+          <diamond-enter type="fade" delay={0.4}>
+            <locator-icon icon={recyclable ? 'tick-circle' : 'cross-circle'} />
+            <h3>{t(`material.hero.${recyclable ? 'yes' : 'no'}`)}</h3>
+          </diamond-enter>
         </locator-wrap>
       </locator-hero>
       <diamond-enter type="fade-in-up" delay={0.25}>

--- a/src/pages/[postcode]/material/material.page.tsx
+++ b/src/pages/[postcode]/material/material.page.tsx
@@ -1,6 +1,7 @@
 import { Suspense } from 'preact/compat';
+import { useEffect } from 'preact/hooks';
 import { useTranslation } from 'react-i18next';
-import { useAsyncValue, Await } from 'react-router-dom';
+import { Await, Link, useLoaderData, useParams } from 'react-router-dom';
 import '@etchteam/diamond-ui/composition/Enter/Enter';
 
 import '@/components/canvas/Loading/Loading';
@@ -8,16 +9,19 @@ import '@/components/content/Icon/Icon';
 import '@/components/canvas/LoadingCard/LoadingCard';
 import '@/components/canvas/Hero/Hero';
 import '@/components/composition/Wrap/Wrap';
+import TipContent from '@/components/template/TipContent/TipContent';
+import config from '@/config';
 import getPropertiesByMaterial from '@/lib/getPropertiesByMaterial';
+import useAnalytics from '@/lib/useAnalytics';
 
 import NearbyPlaces from './NearbyPlaces';
 import RecycleAtHome from './RecycleAtHome';
 import {
-  MaterialLoaderResponse,
-  useMaterialLoaderData,
+  DeferredMaterialLoaderResponse,
+  AwaitedMaterialLoaderResponse,
 } from './material.loader';
 
-function Loading() {
+export function Loading() {
   const { t } = useTranslation();
 
   return (
@@ -36,10 +40,12 @@ function Loading() {
   );
 }
 
-function MaterialPageContent() {
+function MaterialPageContent({
+  localAuthority,
+  locations,
+  materialId,
+}: Partial<AwaitedMaterialLoaderResponse>) {
   const { t } = useTranslation();
-  const { localAuthority, locations, materialId } =
-    useAsyncValue() as MaterialLoaderResponse;
   const propertiesCollectingThisMaterial = getPropertiesByMaterial(
     materialId,
     localAuthority.properties,
@@ -77,13 +83,69 @@ function MaterialPageContent() {
 }
 
 export default function MaterialPage() {
-  const { data } = useMaterialLoaderData();
+  const { postcode } = useParams();
+  const { recordEvent } = useAnalytics();
+  const {
+    materialId,
+    materialName,
+    tip: tipPromise,
+    localAuthority: localAuthorityPromise,
+    locations: locationsPromise,
+  } = useLoaderData() as DeferredMaterialLoaderResponse;
+
+  useEffect(() => {
+    if (materialName) {
+      recordEvent({
+        category: 'MaterialResult::MaterialSearch',
+        action: materialName,
+      });
+    }
+  }, [materialName]);
 
   return (
-    <Suspense fallback={<Loading />}>
-      <Await resolve={data}>
-        <MaterialPageContent />
-      </Await>
-    </Suspense>
+    <>
+      <div slot="layout-main">
+        {materialId && (
+          <Link
+            to={`/${postcode}/material/search`}
+            className="diamond-text-decoration-none"
+          >
+            <locator-context-header>
+              <div className="diamond-text-weight-bold">{materialName}</div>
+              <locator-icon icon="search" color="primary" />
+            </locator-context-header>
+          </Link>
+        )}
+        <Suspense fallback={<Loading />}>
+          <Await
+            resolve={Promise.all([localAuthorityPromise, locationsPromise])}
+          >
+            {([localAuthority, locations]) => {
+              return (
+                <MaterialPageContent
+                  localAuthority={localAuthority}
+                  locations={locations}
+                  materialId={materialId}
+                />
+              );
+            }}
+          </Await>
+        </Suspense>
+      </div>
+      <locator-tip slot="layout-aside" text-align="center">
+        <locator-wrap>
+          <img
+            className="diamond-spacing-bottom-sm"
+            src={config.imagePath + 'material-tip.svg'}
+            alt=""
+          />
+          <Suspense fallback={null}>
+            <Await resolve={tipPromise}>
+              {(tip) => <TipContent tip={tip} />}
+            </Await>
+          </Suspense>
+        </locator-wrap>
+      </locator-tip>
+    </>
   );
 }

--- a/src/pages/[postcode]/material/material.routes.tsx
+++ b/src/pages/[postcode]/material/material.routes.tsx
@@ -13,12 +13,12 @@ const routes: RouteObject[] = [
   {
     path: '/:postcode/material',
     element: <MaterialLayout />,
-    loader: materialLoader,
-    id: 'material',
     children: [
       {
         index: true,
         element: <MaterialPage />,
+        loader: materialLoader,
+        id: 'material',
         errorElement: <MaterialErrorPage />,
       },
       {

--- a/src/pages/[postcode]/material/material.routes.tsx
+++ b/src/pages/[postcode]/material/material.routes.tsx
@@ -17,9 +17,8 @@ const routes: RouteObject[] = [
       {
         index: true,
         element: <MaterialPage />,
-        loader: materialLoader,
-        id: 'material',
         errorElement: <MaterialErrorPage />,
+        loader: materialLoader,
       },
       {
         path: 'search',

--- a/src/pages/[postcode]/material/search.page.tsx
+++ b/src/pages/[postcode]/material/search.page.tsx
@@ -16,6 +16,8 @@ import '@/components/composition/Wrap/Wrap';
 import '@/components/composition/BorderedList/BorderedList';
 import MaterialSearchInput from '@/components/control/MaterialSearchInput/MaterialSearchInput';
 import PopularMaterials from '@/components/template/PopularMaterials/PopularMaterials';
+import TipContent from '@/components/template/TipContent/TipContent';
+import config from '@/config';
 import useFormValidation from '@/lib/useFormValidation';
 import { Material } from '@/types/locatorApi';
 
@@ -26,10 +28,9 @@ export default function MaterialSearchPage() {
   const { postcode } = useParams();
   const form = useFormValidation('search');
   const [searchParams] = useSearchParams();
-  const { data } = useLoaderData() as {
-    data: Promise<MaterialSearchLoaderResponse>;
-  };
   const materialName = searchParams.get('name');
+  const { popularMaterials: popularMaterialsPromise, tip: tipPromise } =
+    useLoaderData() as MaterialSearchLoaderResponse;
 
   useEffect(() => {
     form.submitting.value = false;
@@ -42,42 +43,64 @@ export default function MaterialSearchPage() {
   }
 
   return (
-    <locator-wrap>
-      <diamond-section padding="lg">
-        {materialName && (
-          <h3>
-            {t('material.search.notFound')}{' '}
-            <span className="diamond-text-weight-bold">
-              {materialName.toLocaleLowerCase()}
-            </span>
-          </h3>
-        )}
-        <Form method="post" onSubmit={form.handleSubmit}>
-          <diamond-form-group>
-            <label htmlFor="locator-material-input">
-              {t('actions.searchAgain')}
-            </label>
-            <MaterialSearchInput
-              handleBlur={form.handleBlur}
-              handleInput={form.handleInput}
-              submitting={form.submitting.value}
-              valid={form.valid.value}
-            ></MaterialSearchInput>
-            <p className="diamond-text-size-sm">{t('material.search.help')}</p>
-          </diamond-form-group>
-        </Form>
+    <>
+      <div slot="layout-main">
+        <locator-wrap>
+          <diamond-section padding="lg">
+            <diamond-enter type="fade">
+              {materialName && (
+                <h3>
+                  {t('material.search.notFound')}{' '}
+                  <span className="diamond-text-weight-bold">
+                    {materialName.toLocaleLowerCase()}
+                  </span>
+                </h3>
+              )}
+              <Form method="post" onSubmit={form.handleSubmit}>
+                <diamond-form-group>
+                  <label htmlFor="locator-material-input">
+                    {t('actions.searchAgain')}
+                  </label>
+                  <MaterialSearchInput
+                    handleBlur={form.handleBlur}
+                    handleInput={form.handleInput}
+                    submitting={form.submitting.value}
+                    valid={form.valid.value}
+                  ></MaterialSearchInput>
+                  <p className="diamond-text-size-sm">
+                    {t('material.search.help')}
+                  </p>
+                </diamond-form-group>
+              </Form>
+            </diamond-enter>
 
-        <Suspense fallback={/* No loading UI necessary */ null}>
-          <Await resolve={data}>
-            {({ popularMaterials }) => (
-              <PopularMaterials
-                materials={popularMaterials}
-                generatePath={generatePopularMaterialPath}
-              />
-            )}
-          </Await>
-        </Suspense>
-      </diamond-section>
-    </locator-wrap>
+            <Suspense fallback={/* No loading UI necessary */ null}>
+              <Await resolve={popularMaterialsPromise}>
+                {(popularMaterials) => (
+                  <PopularMaterials
+                    materials={popularMaterials}
+                    generatePath={generatePopularMaterialPath}
+                  />
+                )}
+              </Await>
+            </Suspense>
+          </diamond-section>
+        </locator-wrap>
+      </div>
+      <locator-tip slot="layout-aside" text-align="center">
+        <locator-wrap>
+          <img
+            className="diamond-spacing-bottom-sm"
+            src={config.imagePath + 'material-tip.svg'}
+            alt=""
+          />
+          <Suspense fallback={null}>
+            <Await resolve={tipPromise}>
+              {(tip) => <TipContent tip={tip} />}
+            </Await>
+          </Suspense>
+        </locator-wrap>
+      </locator-tip>
+    </>
   );
 }

--- a/src/pages/[postcode]/material/search.page.tsx
+++ b/src/pages/[postcode]/material/search.page.tsx
@@ -47,7 +47,7 @@ export default function MaterialSearchPage() {
       <div slot="layout-main">
         <locator-wrap>
           <diamond-section padding="lg">
-            <diamond-enter type="fade">
+            <diamond-enter type="fade" className="layer-one">
               {materialName && (
                 <h3>
                   {t('material.search.notFound')}{' '}

--- a/src/pages/[postcode]/places/place/details.page.tsx
+++ b/src/pages/[postcode]/places/place/details.page.tsx
@@ -1,17 +1,26 @@
 import nl2br from 'nl2br';
+import { Suspense } from 'preact/compat';
 import { useTranslation } from 'react-i18next';
-import { useRouteLoaderData } from 'react-router-dom';
+import { Await } from 'react-router-dom';
 
 import '@/components/composition/BorderedList/BorderedList';
-import { PlaceLoaderResponse } from './place.loader';
+import { Location } from '@/types/locatorApi';
 
-export default function PlaceDetailsPage() {
+import { usePlaceLoaderData } from './place.loader';
+
+function PlaceDetailsPageContent({
+  location,
+}: {
+  readonly location: Location;
+}) {
   const { t } = useTranslation();
-  const { location } = useRouteLoaderData('place') as PlaceLoaderResponse;
+
+  if (location.error) {
+    throw new Error(location.error);
+  }
 
   return (
-    <>
-      <h3 className="diamond-spacing-bottom-md">{t('place.details.title')}</h3>
+    <diamond-enter type="fade">
       <locator-bordered-list size="sm">
         <dl>
           <div>
@@ -58,6 +67,23 @@ export default function PlaceDetailsPage() {
           )}
         </dl>
       </locator-bordered-list>
+    </diamond-enter>
+  );
+}
+
+export default function PlaceDetailsPage() {
+  const { t } = useTranslation();
+  const { location: locationPromise } = usePlaceLoaderData();
+
+  return (
+    <>
+      <h3 className="diamond-spacing-bottom-md">{t('place.details.title')}</h3>
+
+      <Suspense fallback={null}>
+        <Await resolve={locationPromise}>
+          {(location) => <PlaceDetailsPageContent location={location} />}
+        </Await>
+      </Suspense>
     </>
   );
 }

--- a/src/pages/[postcode]/places/place/place.loader.ts
+++ b/src/pages/[postcode]/places/place/place.loader.ts
@@ -1,19 +1,23 @@
-import { LoaderFunctionArgs } from 'react-router-dom';
+import { LoaderFunctionArgs, useRouteLoaderData } from 'react-router-dom';
 
 import LocatorApi from '@/lib/LocatorApi';
 import { Location } from '@/types/locatorApi';
 
 export interface PlaceLoaderResponse {
-  location: Location;
+  location: Promise<Location>;
 }
 
 export default async function placeLoader({ params }: LoaderFunctionArgs) {
   // TODO(WRAP-207): Use params.id instead
-  const location = await LocatorApi.get<Location>(
+  const location = LocatorApi.get<Location>(
     `location/${params.placeName}/${params.placePostcode}`,
   );
 
   return {
     location,
   };
+}
+
+export function usePlaceLoaderData() {
+  return useRouteLoaderData('place') as PlaceLoaderResponse;
 }

--- a/src/pages/[postcode]/places/places.layout.tsx
+++ b/src/pages/[postcode]/places/places.layout.tsx
@@ -28,7 +28,7 @@ export default function PlacesLayout({
 }) {
   const { t } = useTranslation();
   const { postcode } = useParams();
-  const { data } = usePlacesLoaderData();
+  const { locations: locationsPromise } = usePlacesLoaderData();
   const open = useSignal(false);
   const [searchParams, setSearchParams] = useSearchParams();
   const materialId = searchParams.get('materialId');
@@ -96,12 +96,12 @@ export default function PlacesLayout({
               <locator-places-header-search>
                 {materialName && (
                   <Suspense fallback={null}>
-                    <Await resolve={data}>
-                      {({ locations }) => (
+                    <Await resolve={locationsPromise}>
+                      {(locations) => (
                         <diamond-enter type="fade">
                           <locator-tag-button
                             variant={
-                              locations?.length > 0 &&
+                              locations?.items.length > 0 &&
                               materialId !== 'undefined'
                                 ? 'positive'
                                 : 'negative'
@@ -120,7 +120,10 @@ export default function PlacesLayout({
                     </Await>
                   </Suspense>
                 )}
-                <Link to={`/${postcode}/places/search${query}`}>
+                <Link
+                  to={`/${postcode}/places/search${query}`}
+                  unstable_viewTransition
+                >
                   {!materialName && t('places.searchPlaceholder')}
                   <locator-icon icon="search" color="primary" />
                 </Link>

--- a/src/pages/[postcode]/places/places.routes.tsx
+++ b/src/pages/[postcode]/places/places.routes.tsx
@@ -21,38 +21,35 @@ const routes: RouteObject[] = [
   {
     path: '/:postcode/places',
     errorElement: <PlacesErrorPage />,
+    element: <PlacesLayout />,
+    loader: placesLoader,
+    id: 'places',
     children: [
       {
-        element: <PlacesLayout />,
-        loader: placesLoader,
-        id: 'places',
-        children: [
-          {
-            index: true,
-            element: <PlacesPage />,
-          },
-          {
-            path: 'map',
-            element: <PlacesMapPage />,
-          },
-        ],
+        index: true,
+        element: <PlacesPage />,
       },
       {
-        path: 'search',
-        element: <PlacesSearchLayout />,
-        children: [
-          {
-            index: true,
-            element: <PlacesSearchPage />,
-            action: placesSearchAction,
-            loader: placesSearchLoader,
-          },
-          {
-            path: 'a-z',
-            element: <AtoZPage />,
-            loader: placesMaterialsLoader,
-          },
-        ],
+        path: 'map',
+        element: <PlacesMapPage />,
+      },
+    ],
+  },
+  {
+    path: '/:postcode/places/search',
+    element: <PlacesSearchLayout />,
+    errorElement: <PlacesErrorPage />,
+    children: [
+      {
+        index: true,
+        element: <PlacesSearchPage />,
+        action: placesSearchAction,
+        loader: placesSearchLoader,
+      },
+      {
+        path: 'a-z',
+        element: <AtoZPage />,
+        loader: placesMaterialsLoader,
       },
     ],
   },

--- a/src/pages/[postcode]/places/places.routes.tsx
+++ b/src/pages/[postcode]/places/places.routes.tsx
@@ -20,12 +20,12 @@ import PlacesSearchPage from './search/search.page';
 const routes: RouteObject[] = [
   {
     path: '/:postcode/places',
-    loader: placesLoader,
-    id: 'places',
+    errorElement: <PlacesErrorPage />,
     children: [
       {
         element: <PlacesLayout />,
-        errorElement: <PlacesErrorPage />,
+        loader: placesLoader,
+        id: 'places',
         children: [
           {
             index: true,
@@ -40,7 +40,6 @@ const routes: RouteObject[] = [
       {
         path: 'search',
         element: <PlacesSearchLayout />,
-        errorElement: <PlacesErrorPage />,
         children: [
           {
             index: true,

--- a/src/pages/[postcode]/places/search/a-z.page.tsx
+++ b/src/pages/[postcode]/places/search/a-z.page.tsx
@@ -1,22 +1,28 @@
 import groupBy from 'lodash/groupBy';
+import { Suspense } from 'preact/compat';
 import { useTranslation } from 'react-i18next';
-import { Link, useLoaderData, useParams } from 'react-router-dom';
+import { Await, Link, useLoaderData, useParams } from 'react-router-dom';
 import '@etchteam/diamond-ui/control/Button/Button';
 import '@etchteam/diamond-ui/composition/Grid/Grid';
 import '@etchteam/diamond-ui/composition/Grid/GridItem';
+import '@etchteam/diamond-ui/composition/Enter/Enter';
 
 import '@/components/composition/Wrap/Wrap';
 import '@/components/control/AlphabetNav/AlphabetNav';
 import '@/components/composition/BorderedList/BorderedList';
 import '@/components/content/Icon/Icon';
 import tArray from '@/lib/tArray';
+import { Material } from '@/types/locatorApi';
 
 import { PlacesMaterialsLoaderResponse } from './materials.loader';
 
-export default function AtoZPage() {
+function AtoZPageContent({
+  materials,
+}: {
+  readonly materials: readonly Material[];
+}) {
   const { t } = useTranslation();
   const { postcode } = useParams();
-  const { materials } = useLoaderData() as PlacesMaterialsLoaderResponse;
   const alphabet = tArray('places.search.aToZ.alphabet');
   const multiLetterChars = alphabet.filter((letter) => letter.length > 1);
   const groupedMaterials = groupBy(materials, (material) => {
@@ -55,7 +61,7 @@ export default function AtoZPage() {
   }
 
   return (
-    <>
+    <diamond-enter type="fade">
       <locator-alphabet-nav className="diamond-spacing-bottom-lg">
         <nav>
           <ul>
@@ -119,6 +125,18 @@ export default function AtoZPage() {
           </locator-bordered-list>
         </>
       ))}
-    </>
+    </diamond-enter>
+  );
+}
+
+export default function AtoZPage() {
+  const { materials } = useLoaderData() as PlacesMaterialsLoaderResponse;
+
+  return (
+    <Suspense fallback={null}>
+      <Await resolve={materials}>
+        {(materials) => <AtoZPageContent materials={materials} />}
+      </Await>
+    </Suspense>
   );
 }

--- a/src/pages/[postcode]/places/search/materials.loader.ts
+++ b/src/pages/[postcode]/places/search/materials.loader.ts
@@ -1,12 +1,14 @@
+import { defer } from 'react-router-dom';
+
 import LocatorApi from '@/lib/LocatorApi';
 import { Material } from '@/types/locatorApi';
 
 export interface PlacesMaterialsLoaderResponse {
-  materials: Material[];
+  materials: Promise<Material[]>;
 }
 
 export default async function placesMaterialsLoader() {
-  const materials = await LocatorApi.get<Material[]>('materials');
+  const materials = LocatorApi.get<Material[]>('materials');
 
-  return { materials };
+  return defer({ materials });
 }

--- a/src/pages/[postcode]/places/search/search.layout.tsx
+++ b/src/pages/[postcode]/places/search/search.layout.tsx
@@ -1,4 +1,5 @@
 import { ComponentChildren } from 'preact';
+import { useRef } from 'preact/hooks';
 import { useTranslation } from 'react-i18next';
 import {
   Link,
@@ -16,6 +17,7 @@ import '@/components/composition/Wrap/Wrap';
 import '@/components/content/HeaderTitle/HeaderTitle';
 import '@/components/content/Icon/Icon';
 import '@/components/control/NavBar/NavBar';
+import useScrollRestoration from '@/lib/useScrollRestoration';
 
 export default function PlacesSearchLayout({
   children,
@@ -24,6 +26,8 @@ export default function PlacesSearchLayout({
 }) {
   const { t } = useTranslation();
   const { postcode } = useParams();
+  const layoutRef = useRef();
+  useScrollRestoration(layoutRef);
   const [searchParams] = useSearchParams();
   const materialId = searchParams.get('materialId');
   const materialName = searchParams.get('materialName');
@@ -44,7 +48,7 @@ export default function PlacesSearchLayout({
             <h2>{t('places.search.title')}</h2>
           </locator-header-title>
           <diamond-button width="square" size="sm">
-            <Link to={`/${postcode}/places${query}`}>
+            <Link to={`/${postcode}/places${query}`} unstable_viewTransition>
               <locator-icon
                 icon="close"
                 color="primary"
@@ -54,17 +58,24 @@ export default function PlacesSearchLayout({
           </diamond-button>
         </locator-header-content>
       </locator-header>
-      <div slot="layout-main">
+      <div slot="layout-main" ref={layoutRef}>
         <locator-nav-bar>
           <nav>
             <ul>
               <li>
-                <NavLink to={`/${postcode}/places/search`} end>
+                <NavLink
+                  to={`/${postcode}/places/search`}
+                  unstable_viewTransition
+                  end
+                >
                   {t('places.search.nav.search')}
                 </NavLink>
               </li>
               <li>
-                <NavLink to={`/${postcode}/places/search/a-z`}>
+                <NavLink
+                  to={`/${postcode}/places/search/a-z`}
+                  unstable_viewTransition
+                >
                   {t('places.search.nav.aToZ')}
                 </NavLink>
               </li>

--- a/src/pages/[postcode]/places/search/search.loader.ts
+++ b/src/pages/[postcode]/places/search/search.loader.ts
@@ -5,27 +5,18 @@ import LocatorApi from '@/lib/LocatorApi';
 import { Material } from '@/types/locatorApi';
 
 export interface PlacesSearchLoaderResponse {
-  popularMaterials: Material[];
-}
-
-async function getData(): Promise<PlacesSearchLoaderResponse> {
-  try {
-    const popularMaterials = await LocatorApi.get<Material[]>(
-      'materials?popular=true',
-    );
-
-    return {
-      popularMaterials,
-    };
-  } catch (error) {
-    Sentry.captureException(error, {
-      tags: { route: 'Places search loader' },
-    });
-    // Let the user carry on without the popularMaterials
-    return Promise.resolve({ popularMaterials: [] });
-  }
+  popularMaterials: Promise<Material[]>;
 }
 
 export default async function placesSearchLoader() {
-  return defer({ data: getData() });
+  const popularMaterials = LocatorApi.get<Material[]>(
+    'materials?popular=true',
+  ).catch((error) => {
+    Sentry.captureException(error, {
+      tags: { route: 'Places search loader' },
+    });
+    return Promise.resolve([]);
+  });
+
+  return defer({ popularMaterials });
 }

--- a/src/pages/[postcode]/places/search/search.page.tsx
+++ b/src/pages/[postcode]/places/search/search.page.tsx
@@ -8,6 +8,7 @@ import {
   useSearchParams,
 } from 'react-router-dom';
 import '@etchteam/diamond-ui/composition/FormGroup/FormGroup';
+import '@etchteam/diamond-ui/composition/Enter/Enter';
 
 import MaterialSearchInput from '@/components/control/MaterialSearchInput/MaterialSearchInput';
 import PopularMaterials from '@/components/template/PopularMaterials/PopularMaterials';
@@ -19,9 +20,7 @@ import { PlacesSearchLoaderResponse } from './search.loader';
 export default function PlacesSearchPage() {
   const { t } = useTranslation();
   const { postcode } = useParams();
-  const { data } = useLoaderData() as {
-    data: Promise<PlacesSearchLoaderResponse>;
-  };
+  const { popularMaterials } = useLoaderData() as PlacesSearchLoaderResponse;
   const [searchParams] = useSearchParams();
   const autofocus = searchParams.get('autofocus') === 'true';
   const form = useFormValidation('search');
@@ -35,21 +34,23 @@ export default function PlacesSearchPage() {
   return (
     <>
       <h3 id="places-search-label">{t('places.search.label')}</h3>
-      <Form method="post" onSubmit={form.handleSubmit}>
-        <diamond-form-group>
-          <MaterialSearchInput
-            inputLabelledBy="places-search-label"
-            autofocus={autofocus}
-            handleBlur={form.handleBlur}
-            handleInput={form.handleInput}
-            submitting={form.submitting.value}
-            valid={form.valid.value}
-          ></MaterialSearchInput>
-        </diamond-form-group>
-      </Form>
+      <diamond-enter type="fade" className="layer-one">
+        <Form method="post" onSubmit={form.handleSubmit}>
+          <diamond-form-group>
+            <MaterialSearchInput
+              inputLabelledBy="places-search-label"
+              autofocus={autofocus}
+              handleBlur={form.handleBlur}
+              handleInput={form.handleInput}
+              submitting={form.submitting.value}
+              valid={form.valid.value}
+            ></MaterialSearchInput>
+          </diamond-form-group>
+        </Form>
+      </diamond-enter>
       <Suspense fallback={/* No loading UI necessary */ null}>
-        <Await resolve={data}>
-          {({ popularMaterials }) => (
+        <Await resolve={popularMaterials}>
+          {(popularMaterials) => (
             <PopularMaterials
               materials={popularMaterials}
               generatePath={generatePopularMaterialPath}

--- a/src/pages/[postcode]/postcode.page.tsx
+++ b/src/pages/[postcode]/postcode.page.tsx
@@ -5,6 +5,7 @@ import { Link, Form, Await, useSearchParams } from 'react-router-dom';
 import '@etchteam/diamond-ui/canvas/Section/Section';
 import '@etchteam/diamond-ui/composition/Grid/Grid';
 import '@etchteam/diamond-ui/composition/Grid/GridItem';
+import '@etchteam/diamond-ui/composition/Enter/Enter';
 import '@etchteam/diamond-ui/control/Button/Button';
 
 import '@/components/canvas/ContextHeader/ContextHeader';

--- a/src/pages/[postcode]/postcode.page.tsx
+++ b/src/pages/[postcode]/postcode.page.tsx
@@ -120,7 +120,7 @@ export default function PostcodePage() {
       </locator-context-header>
       <locator-wrap>
         <diamond-section padding="lg">
-          <diamond-enter type="fade">
+          <diamond-enter type="fade" className="layer-one">
             <h2
               id="material-search-title"
               className="diamond-text-size-h3 diamond-spacing-bottom-md"

--- a/src/pages/[postcode]/postcode.page.tsx
+++ b/src/pages/[postcode]/postcode.page.tsx
@@ -120,56 +120,60 @@ export default function PostcodePage() {
       </locator-context-header>
       <locator-wrap>
         <diamond-section padding="lg">
-          <h2
-            id="material-search-title"
-            className="diamond-text-size-h3 diamond-spacing-bottom-md"
-          >
-            {t('postcode.title')}
-          </h2>
+          <diamond-enter type="fade">
+            <h2
+              id="material-search-title"
+              className="diamond-text-size-h3 diamond-spacing-bottom-md"
+            >
+              {t('postcode.title')}
+            </h2>
 
-          <Form method="post" onSubmit={form.handleSubmit}>
-            <MaterialSearchInput
-              inputLabelledBy="material-search-title"
-              autofocus={autofocus}
-              handleBlur={form.handleBlur}
-              handleInput={form.handleInput}
-              submitting={form.submitting.value}
-              valid={form.valid.value}
-            ></MaterialSearchInput>
-          </Form>
+            <Form method="post" onSubmit={form.handleSubmit}>
+              <MaterialSearchInput
+                inputLabelledBy="material-search-title"
+                autofocus={autofocus}
+                handleBlur={form.handleBlur}
+                handleInput={form.handleInput}
+                submitting={form.submitting.value}
+                valid={form.valid.value}
+              ></MaterialSearchInput>
+            </Form>
+          </diamond-enter>
 
-          <locator-bordered-list className="diamond-spacing-top-lg">
-            <nav>
-              <ul>
-                <li>
-                  <locator-icon-link>
-                    <Link to={`/${postcode}/home`}>
-                      <locator-icon-circle>
-                        <locator-icon
-                          icon="home"
-                          color="primary"
-                        ></locator-icon>
-                      </locator-icon-circle>
-                      {t('postcode.options.home')}
-                    </Link>
-                  </locator-icon-link>
-                </li>
-                <li>
-                  <locator-icon-link>
-                    <Link to={`/${postcode}/places`}>
-                      <locator-icon-circle>
-                        <locator-icon
-                          icon="distance"
-                          color="primary"
-                        ></locator-icon>
-                      </locator-icon-circle>
-                      {t('postcode.options.nearest')}
-                    </Link>
-                  </locator-icon-link>
-                </li>
-              </ul>
-            </nav>
-          </locator-bordered-list>
+          <diamond-enter type="fade-in-up" delay={0.25}>
+            <locator-bordered-list className="diamond-spacing-top-lg">
+              <nav>
+                <ul>
+                  <li>
+                    <locator-icon-link>
+                      <Link to={`/${postcode}/home`} unstable_viewTransition>
+                        <locator-icon-circle>
+                          <locator-icon
+                            icon="home"
+                            color="primary"
+                          ></locator-icon>
+                        </locator-icon-circle>
+                        {t('postcode.options.home')}
+                      </Link>
+                    </locator-icon-link>
+                  </li>
+                  <li>
+                    <locator-icon-link>
+                      <Link to={`/${postcode}/places`} unstable_viewTransition>
+                        <locator-icon-circle>
+                          <locator-icon
+                            icon="distance"
+                            color="primary"
+                          ></locator-icon>
+                        </locator-icon-circle>
+                        {t('postcode.options.nearest')}
+                      </Link>
+                    </locator-icon-link>
+                  </li>
+                </ul>
+              </nav>
+            </locator-bordered-list>
+          </diamond-enter>
         </diamond-section>
       </locator-wrap>
     </StartLayout>

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -14,3 +14,4 @@
 @import './tokens/label.css';
 @import './tokens/theme.css';
 @import './tokens/wrap.css';
+@import './tokens/layer.css';

--- a/src/styles/tokens/layer.css
+++ b/src/styles/tokens/layer.css
@@ -1,0 +1,4 @@
+:host {
+  --layer-one: 1;
+  --layer-two: 2;
+}

--- a/src/styles/utils.css
+++ b/src/styles/utils.css
@@ -14,3 +14,8 @@
 .text-color-negative {
   color: var(--color-red-dark);
 }
+
+.layer-one {
+  position: relative;
+  z-index: var(--layer-one);
+}

--- a/src/types/locatorApi.ts
+++ b/src/types/locatorApi.ts
@@ -106,6 +106,7 @@ export interface Location {
     source: 'valpak' | 'wrap';
     materials: MaterialWithCategory[];
   }[];
+  error?: string;
 }
 
 export interface LocationsResponse {

--- a/tests/end-to-end/places.test.ts
+++ b/tests/end-to-end/places.test.ts
@@ -61,6 +61,10 @@ describeEndToEndTest('Places', () => {
               ...mockLocation,
               id: i,
             })),
+            pagination: {
+              total: 60,
+              page: 1,
+            },
           },
         });
       },

--- a/tests/mocks/recyclingMeta.ts
+++ b/tests/mocks/recyclingMeta.ts
@@ -1,7 +1,7 @@
 import config from '@/config';
 import { RecyclingMeta } from '@/types/locatorApi';
 
-export const RECYCLING_META_ENDPOINT = `${config.locatorApiPath}recycling-meta?categories=HINT&lang=en-GB`;
+export const RECYCLING_META_ENDPOINT = `${config.locatorApiPath}recycling-meta**`;
 
 export const RecyclingMetaResponse: RecyclingMeta[] = [
   {

--- a/tests/unit/sortPropertyTypes.test.ts
+++ b/tests/unit/sortPropertyTypes.test.ts
@@ -19,14 +19,16 @@ test('sorts properties in the correct order', () => {
     },
   };
 
-  expect(Object.keys(LocalAuthorityMock.properties)).toBe([
+  expect(Object.keys(LocalAuthorityMock.properties)).toStrictEqual([
     PROPERTY_TYPE.ALL,
     PROPERTY_TYPE.KERBSIDE,
     PROPERTY_TYPE.NARROW_ACCESS,
     PROPERTY_TYPE.FLATS_WITH_INDIVIDUAL_BINS,
   ]);
 
-  expect(Object.keys(sortPropertyTypes(LocalAuthorityMock.properties))).toBe([
+  expect(
+    Object.keys(sortPropertyTypes(LocalAuthorityMock.properties)),
+  ).toStrictEqual([
     PROPERTY_TYPE.KERBSIDE,
     PROPERTY_TYPE.FLATS_WITH_INDIVIDUAL_BINS,
     PROPERTY_TYPE.NARROW_ACCESS,

--- a/tests/unit/sortPropertyTypes.test.ts
+++ b/tests/unit/sortPropertyTypes.test.ts
@@ -1,0 +1,35 @@
+import { expect, test, beforeAll } from 'vitest';
+
+import provideI18n from '../utils/providei18n';
+import getPropertyTypeEnum from '@/lib/getPropertyTypeEnum';
+import sortPropertyTypes from '@/lib/sortPropertyTypes';
+
+beforeAll(async () => {
+  await provideI18n();
+});
+
+test('sorts properties in the correct order', () => {
+  const PROPERTY_TYPE = getPropertyTypeEnum();
+  const LocalAuthorityMock = {
+    properties: {
+      [PROPERTY_TYPE.ALL]: [],
+      [PROPERTY_TYPE.KERBSIDE]: [],
+      [PROPERTY_TYPE.NARROW_ACCESS]: [],
+      [PROPERTY_TYPE.FLATS_WITH_INDIVIDUAL_BINS]: [],
+    },
+  };
+
+  expect(Object.keys(LocalAuthorityMock.properties)).toBe([
+    PROPERTY_TYPE.ALL,
+    PROPERTY_TYPE.KERBSIDE,
+    PROPERTY_TYPE.NARROW_ACCESS,
+    PROPERTY_TYPE.FLATS_WITH_INDIVIDUAL_BINS,
+  ]);
+
+  expect(Object.keys(sortPropertyTypes(LocalAuthorityMock.properties))).toBe([
+    PROPERTY_TYPE.KERBSIDE,
+    PROPERTY_TYPE.FLATS_WITH_INDIVIDUAL_BINS,
+    PROPERTY_TYPE.NARROW_ACCESS,
+    PROPERTY_TYPE.ALL,
+  ]);
+});

--- a/tests/utils/snapshot.ts
+++ b/tests/utils/snapshot.ts
@@ -1,16 +1,20 @@
-import percySnapshot from '@percy/playwright';
+/* eslint-disable @typescript-eslint/no-unused-vars */
+// import percySnapshot from '@percy/playwright';
 import { Page } from 'playwright';
 
 export default async function snapshot(page: Page, name: string) {
-  if (!process.env.PERCY_TOKEN) {
-    return;
-  }
+  // Percy is temporarily disabled
+  return;
 
-  try {
-    await percySnapshot(page, name, {
-      percyCSS: 'recycling-locator { height: auto !important; }',
-    });
-  } catch (error) {
-    console.error(error);
-  }
+  // if (!process.env.PERCY_TOKEN) {
+  //   return;
+  // }
+
+  // try {
+  //   await percySnapshot(page, name, {
+  //     percyCSS: 'recycling-locator { height: auto !important; }',
+  //   });
+  // } catch (error) {
+  //   console.error(error);
+  // }
 }

--- a/tests/utils/snapshot.ts
+++ b/tests/utils/snapshot.ts
@@ -6,7 +6,11 @@ export default async function snapshot(page: Page, name: string) {
     return;
   }
 
-  await percySnapshot(page, name, {
-    percyCSS: 'recycling-locator { height: auto !important; }',
-  });
+  try {
+    await percySnapshot(page, name, {
+      percyCSS: 'recycling-locator { height: auto !important; }',
+    });
+  } catch (error) {
+    console.error(error);
+  }
 }


### PR DESCRIPTION
Improves responsiveness and transitions between every view on the app by:

- Fixing link click delays, this was caused by react-router waiting for loaders even when they're deferred, all loaders have been refactored, individual properties are returned as promises instead of grouped up into an object, then route loaders are decoupled from route layouts for routes which don't share the loader. This is the biggest change because it caused a lot of restructuring.
- Fixing scroll restoration, unfortunately I've had to roll a custom solution for this on some views where we're using nested shadow DOM the built in scroll handling can't find the right element to reset the scroll of between views
- Using more enter animations in specific places by manually clicking through, reviewing and tweaking
- Making use of unstable_viewTransition to provide a native view transition between the content of two views where it makes sense, the "unstable_" part is to do with the react router API potentially changing, not the stability of the feature

It also includes some other fixes which I've included whilst I was making changes to the related part of the UI:

- Fixes WRAP-502 – tidied the tip (caused some translation changes which I've added to the old spreadsheet)
- Fixes WRAP-530 – Scheme menu behaviour, scroll restoration fixed this
- Fixes WRAP-532 – Handled location detail responses with unexpected errors

Percy has been disabled because we reached the snapshot limit for the month on the current plan and it hasn't been helpful. I might look at moving to [playwright snapshots](https://playwright.dev/docs/test-snapshots) instead.