### PR TITLE
Fix category nav ios issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "start": "run-p start:css start:vite",
     "start:css": "npm run build:css -- --watch",
-    "start:vite": "vite",
+    "start:vite": "vite --host",
     "build": "npm run build:css && vite build",
     "build:css": "postcss src/styles/base.css -o public/styles.css",
     "release": "semantic-release",

--- a/src/components/composition/Layout/Layout.css
+++ b/src/components/composition/Layout/Layout.css
@@ -24,17 +24,9 @@ locator-layout {
     --_layout-header-height: auto;
   }
 
-  .recycling-locator-variant-standalone & {
-    min-height: 100cqh;
-  }
-
   &:not(:has([slot='layout-aside'])) {
     grid-template-rows: var(--_layout-header-height) 1fr auto;
     height: var(--container-height);
-
-    .recycling-locator-variant-standalone & {
-      height: 100cqh;
-    }
 
     .recycling-locator-test-mode & {
       height: auto;
@@ -47,10 +39,6 @@ locator-layout {
 
     &:has(locator-places-header) {
       --_layout-header-height: var(--header-height);
-    }
-
-    .recycling-locator-variant-standalone & {
-      height: 100cqh;
     }
 
     .recycling-locator-test-mode & {

--- a/src/components/control/MaterialCategoriesNav/MaterialCategoriesNav.css
+++ b/src/components/control/MaterialCategoriesNav/MaterialCategoriesNav.css
@@ -22,6 +22,7 @@ locator-material-categories-nav {
     background: none;
     border: 0 none;
     border-radius: var(--diamond-border-radius);
+    color: var(--diamond-theme-color);
     column-gap: var(--diamond-spacing-sm);
     cursor: pointer;
     display: inline-flex;
@@ -57,7 +58,7 @@ locator-material-categories-nav {
       background: var(--color-primary-lightest);
     }
 
-    &:has([data-active='true']) > li > button {
+    &.material-categories-nav__categories--has-active > li > button {
       opacity: 0;
       transition:
         opacity var(--diamond-transition),
@@ -128,7 +129,7 @@ locator-material-categories-nav {
     .material-categories-nav__categories {
       border-right: var(--diamond-border);
 
-      &:has([data-active='true']) > li > button {
+      &.material-categories-nav__categories--has-active > li > button {
         opacity: 1;
         visibility: visible;
       }

--- a/src/components/control/MaterialCategoriesNav/MaterialCategoriesNav.tsx
+++ b/src/components/control/MaterialCategoriesNav/MaterialCategoriesNav.tsx
@@ -18,6 +18,7 @@ export default function MaterialCategoriesNav({
   basePath,
 }: MaterialCategoriesNavProps) {
   const activeCategoryId = useSignal<string | null>(null);
+  const hasActive = activeCategoryId.value !== null;
 
   function handleCategoryClick(categoryId: string | null) {
     activeCategoryId.value = categoryId;
@@ -26,7 +27,9 @@ export default function MaterialCategoriesNav({
   return (
     <locator-material-categories-nav>
       <nav>
-        <ul className="material-categories-nav__categories">
+        <ul
+          className={`material-categories-nav__categories ${hasActive ? 'material-categories-nav__categories--has-active' : ''}`}
+        >
           {materialCategories.map((category) => {
             const isActive = activeCategoryId.value === category.id;
             const materialListId = `category-${category.id}-materials`;

--- a/src/lib/AppState.tsx
+++ b/src/lib/AppState.tsx
@@ -16,7 +16,7 @@ export const AppState = createContext<AppStateContext>(null);
 export function createAppState(
   attributes: RecyclingLocatorAttributes,
 ): AppStateContext {
-  const sessionId = (window?.crypto?.randomUUID() ??
+  const sessionId = (window?.crypto?.randomUUID?.() ??
     uniqueId('session')) as unknown as string;
 
   return {

--- a/src/styles/tokens/container.css
+++ b/src/styles/tokens/container.css
@@ -17,3 +17,7 @@
     --container-height: 640px;
   }
 }
+
+.recycling-locator-variant-standalone {
+  --container-height: 100cqh;
+}


### PR DESCRIPTION
- Fixed randomUUID only exists for https so caused an error when testing locally
- Used --container-height for the standalone version to reduce the amount of conditions needed and fix the category search height on the standalone app
- Set the button colour for category nav because IOS colours it as a default browser blue otherwise
- Swapped the :has selector for an active class, IOS couldn't cope with the selector even though it's meant to support it