### PR TITLE
Stop the error spam

### DIFF
--- a/src/components/control/PlacesMap/PlacesMap.tsx
+++ b/src/components/control/PlacesMap/PlacesMap.tsx
@@ -48,7 +48,11 @@ export default class PlacesMap extends Component<PlacesMapProps> {
   enableZoomEvent: boolean;
 
   resizeMap() {
-    this.MapInstance?.getViewPort().resize();
+    try {
+      this.MapInstance?.getViewPort().resize();
+    } catch (error) {
+      // Ignore resize errors
+    }
   }
 
   async initMap() {

--- a/src/lib/useAnalytics.ts
+++ b/src/lib/useAnalytics.ts
@@ -26,11 +26,6 @@ interface AnalyticsEvent {
   ea?: string;
 }
 
-interface AnalyticsResponse {
-  status: 'ok' | 'error';
-  details: string;
-}
-
 async function sendAnalyticsRequest(event: AnalyticsEvent) {
   if (!config.enableAnalytics) {
     return;
@@ -38,18 +33,12 @@ async function sendAnalyticsRequest(event: AnalyticsEvent) {
 
   try {
     const query = new URLSearchParams(event as any);
-    const response = await fetch(`${config.locatorAnalyticsPath}?${query}`, {
+    await fetch(`${config.locatorAnalyticsPath}?${query}`, {
       method: 'GET',
       headers: {
         'X-Requested-With': config.packageVersion,
       },
     });
-
-    const data: AnalyticsResponse = await response.json();
-
-    if (data?.status === 'error') {
-      throw new Error(data.details);
-    }
   } catch (error) {
     Sentry.captureException(error, {
       tags: { analytics: 'sendHit' },

--- a/src/pages/root.layout.tsx
+++ b/src/pages/root.layout.tsx
@@ -28,7 +28,9 @@ export default function RootLayout() {
   }, [startPath, currentHref]);
 
   useEffect(() => {
-    recordView();
+    if (loadedStartPath.value) {
+      recordView();
+    }
   }, [location]);
 
   if (!loadedStartPath.value) {


### PR DESCRIPTION
Fixes WRAP-599
Fixes WRAP-600

- Avoids sending a page view before the start route has loaded, this can happen quickly and cancel the in-flight request
- Removes response.json as the endpoint now always sends back a 204 with empty text (not json)

Other fixes

- getting offset of undefined errors, now ignores here maps complaining when it can't find the offset, this seems to be happening when the map isn't in view
- React router error "Deferred data for key "tip" resolved/rejected with undefined, you must resolve/reject with a value or null." `getTip` will now return null if no tip was found