### PR TITLE
More fixes and refinements from soft launch monitoring

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.36.0",
       "license": "MIT",
       "dependencies": {
-        "@etchteam/diamond-ui": "^1.31.0",
+        "@etchteam/diamond-ui": "^1.31.1",
         "@headlessui/react": "^1.7.18",
         "@here/maps-api-for-javascript": "^1.50.0",
         "@preact/signals": "^1.2.2",
@@ -3426,9 +3426,9 @@
       }
     },
     "node_modules/@etchteam/diamond-ui": {
-      "version": "1.31.0",
-      "resolved": "https://registry.npmjs.org/@etchteam/diamond-ui/-/diamond-ui-1.31.0.tgz",
-      "integrity": "sha512-3kWb/z9x1R0YWNbgiOrgOcBKQwTiJVV6pB8juwvZ4+d3j8BTiAg5vQf6Lo66FZCGyYxAhBtRkKP2072luVhC2Q==",
+      "version": "1.31.1",
+      "resolved": "https://registry.npmjs.org/@etchteam/diamond-ui/-/diamond-ui-1.31.1.tgz",
+      "integrity": "sha512-zqVsfHMCg6tikd05mFkTpi1gDZoGW90q4z5/L2M7l696Dursi8yd1WoD605yjOmdNMwgeWwqX0lKKGnsZ95R/g==",
       "dependencies": {
         "lit": "^3.1.0",
         "modern-normalize": "2.0.0"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "test:end-to-end-debug": "DEBUG=pw:api PWDEBUG=console vitest --ui"
   },
   "dependencies": {
-    "@etchteam/diamond-ui": "^1.31.0",
+    "@etchteam/diamond-ui": "^1.31.1",
     "@headlessui/react": "^1.7.18",
     "@here/maps-api-for-javascript": "^1.50.0",
     "@preact/signals": "^1.2.2",

--- a/src/components/canvas/MapSvg/MapSvg.css
+++ b/src/components/canvas/MapSvg/MapSvg.css
@@ -17,6 +17,7 @@ locator-map-svg {
   }
 
   &::part(content) {
+    box-sizing: border-box;
     margin: 0 auto;
     padding: var(--diamond-spacing);
     width: min(100%, calc(var(--wrap-max-width) - var(--diamond-spacing-lg)));

--- a/src/components/content/Container/Container.stories.tsx
+++ b/src/components/content/Container/Container.stories.tsx
@@ -47,9 +47,6 @@ export const Container: StoryObj = {
           ></locator-container-svg>
           <locator-container-content>
             <locator-container-name>Paid for box</locator-container-name>
-            <locator-container-subscription>
-              Subscription service &ndash; £50
-            </locator-container-subscription>
           </locator-container-content>
         </locator-container>
       </diamond-grid-item>
@@ -63,9 +60,6 @@ export const Container: StoryObj = {
             <locator-container-name>
               Kitchen caddy with notes
             </locator-container-name>
-            <locator-container-notes>
-              Containers can be black or green.
-            </locator-container-notes>
           </locator-container-content>
         </locator-container>
       </diamond-grid-item>
@@ -79,12 +73,6 @@ export const Container: StoryObj = {
             <locator-container-name>
               Paid for kitchen caddy with notes
             </locator-container-name>
-            <locator-container-subscription>
-              Subscription service &ndash; £50
-            </locator-container-subscription>
-            <locator-container-notes>
-              Containers can be black or green.
-            </locator-container-notes>
           </locator-container-content>
         </locator-container>
       </diamond-grid-item>

--- a/src/components/template/SchemeContainerSummary/SchemeContainerSummary.tsx
+++ b/src/components/template/SchemeContainerSummary/SchemeContainerSummary.tsx
@@ -1,5 +1,7 @@
+import uniqueId from 'lodash/uniqueId';
 import { useTranslation } from 'react-i18next';
 
+import '@/components/content/Container/Container';
 import containerName from '@/lib/containerName';
 import { Container } from '@/types/locatorApi';
 
@@ -17,7 +19,10 @@ export default function SchemeContainerSummary({
   return (
     <ul role="list" className="list-style-none diamond-spacing-bottom-md">
       {firstContainers.map((container) => (
-        <li key={container.name} className="diamond-spacing-bottom-sm">
+        <li
+          key={uniqueId(container.name)}
+          className="diamond-spacing-bottom-sm"
+        >
           <locator-container>
             <locator-container-svg
               name={container.name}

--- a/src/lib/sentry.ts
+++ b/src/lib/sentry.ts
@@ -8,18 +8,5 @@ Sentry.init({
   enabled: Boolean(DSN),
   dsn: DSN,
   release: `recycling-locator@${config.packageVersion}`,
-  integrations: [
-    Sentry.browserTracingIntegration(),
-    Sentry.replayIntegration(),
-  ],
-
-  // Set tracesSampleRate to 1.0 to capture 100%
-  // of transactions for performance monitoring.
-  // We recommend adjusting this value in production
-  tracesSampleRate: 1.0,
-
-  // Capture Replay for 10% of all sessions,
-  // plus for 100% of sessions with an error
-  replaysSessionSampleRate: 0.1,
-  replaysOnErrorSampleRate: 1.0,
+  defaultIntegrations: false,
 });

--- a/src/lib/useFormValidation.ts
+++ b/src/lib/useFormValidation.ts
@@ -8,7 +8,8 @@ export default function useFormValidation(fieldName: string) {
   const submitting = useSignal(false);
 
   const handleSubmit = (event) => {
-    const value = new FormData(event.submitter.form).get(fieldName) as string;
+    const form = event?.submitter?.form ?? undefined;
+    const value = new FormData(form).get(fieldName) as string;
 
     if (!value) {
       event.preventDefault();

--- a/src/pages/[postcode]/places/place/place.page.tsx
+++ b/src/pages/[postcode]/places/place/place.page.tsx
@@ -45,7 +45,8 @@ function PlacePageContent({ location }: { readonly location: Location }) {
 
   const handleSearch = (event) => {
     event.preventDefault();
-    const value = new FormData(event.submitter.form).get('search') as string;
+    const form = event?.submitter?.form ?? undefined;
+    const value = new FormData(form).get('search') as string;
 
     if (value) {
       recordEvent({

--- a/src/pages/[postcode]/postcode.page.tsx
+++ b/src/pages/[postcode]/postcode.page.tsx
@@ -64,6 +64,8 @@ function Aside({ postcode }: { readonly postcode: string }) {
       >
         {(locations) => {
           if (locations.error) {
+            // This can happen when the postcode is not found by the API but is found by HERE maps
+            // The postcode checks on the API are stricter
             Sentry.captureMessage(locations.error, {
               tags: { route: 'PostcodeAside' },
             });

--- a/src/pages/[postcode]/postcode.page.tsx
+++ b/src/pages/[postcode]/postcode.page.tsx
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/browser';
 import { Suspense } from 'preact/compat';
 import { useEffect } from 'preact/hooks';
 import { useTranslation } from 'react-i18next';
@@ -61,29 +62,39 @@ function Aside({ postcode }: { readonly postcode: string }) {
         resolve={locationsPromise.data.locations}
         errorElement={<MapErrorFallback postcode={postcode} />}
       >
-        {(locations) => (
-          <PlacesMap
-            latitude={locations.meta.latitude}
-            longitude={locations.meta.longitude}
-            locations={locations.items}
-            static
-          >
-            <Link
-              to={`/${postcode}/places/map`}
-              aria-label={t('actions.showMap')}
+        {(locations) => {
+          if (locations.error) {
+            Sentry.captureMessage(locations.error, {
+              tags: { route: 'PostcodeAside' },
+            });
+
+            return <MapErrorFallback postcode={postcode} />;
+          }
+
+          return (
+            <PlacesMap
+              latitude={locations.meta.latitude}
+              longitude={locations.meta.longitude}
+              locations={locations.items}
+              static
             >
-              <locator-places-map-scrim />
-            </Link>
-            <locator-places-map-card padding="none">
-              <diamond-button width="full-width">
-                <Link to={`/${postcode}/places/map`}>
-                  {t('postcode.exploreTheMap')}
-                  <locator-icon icon="map" color="primary"></locator-icon>
-                </Link>
-              </diamond-button>
-            </locator-places-map-card>
-          </PlacesMap>
-        )}
+              <Link
+                to={`/${postcode}/places/map`}
+                aria-label={t('actions.showMap')}
+              >
+                <locator-places-map-scrim />
+              </Link>
+              <locator-places-map-card padding="none">
+                <diamond-button width="full-width">
+                  <Link to={`/${postcode}/places/map`}>
+                    {t('postcode.exploreTheMap')}
+                    <locator-icon icon="map" color="primary"></locator-icon>
+                  </Link>
+                </diamond-button>
+              </locator-places-map-card>
+            </PlacesMap>
+          );
+        }}
       </Await>
     </Suspense>
   );

--- a/src/pages/start.layout.tsx
+++ b/src/pages/start.layout.tsx
@@ -82,10 +82,12 @@ export default function StartLayout({
   const open = useSignal(false);
 
   open.subscribe((value) => {
-    recordEvent({
-      category: 'About',
-      action: value ? 'Open' : 'Close',
-    });
+    if (value === true) {
+      recordEvent({
+        category: 'About',
+        action: 'Open',
+      });
+    }
   });
 
   return (


### PR DESCRIPTION
- Analytics close event keeps firing so this has changed to only track opens
- Only send manual Sentry errors (that use the captureException or captureMessage) to stop capturing global errors on host sites
- Remove sentry replay recording, it's not working anyway probably because the widget shadow dom
- Handle submitter undefined in old browsers, fixes WRAP-606
- Fix input and map svg button width overflowing to more than the widgets width
- Handle postcodes that the API doesn't understand (WRAP-621)
- Fix preact duplicate key error on home recycling container summaries