### PR TITLE
Enable sentry integrations

### DIFF
--- a/src/lib/sentry.ts
+++ b/src/lib/sentry.ts
@@ -8,5 +8,15 @@ Sentry.init({
   enabled: Boolean(DSN),
   dsn: DSN,
   release: `recycling-locator@${config.packageVersion}`,
+  // Prevent auto capturing of global errors from host sites
   defaultIntegrations: false,
+  // Enable integrations that can be used without capturing host site errors
+  // https://docs.sentry.io/platforms/javascript/configuration/integrations/#modifying-default-integrations
+  integrations: [
+    Sentry.httpContextIntegration(),
+    Sentry.linkedErrorsIntegration(),
+    Sentry.dedupeIntegration(),
+    Sentry.breadcrumbsIntegration(),
+    Sentry.functionToStringIntegration(),
+  ],
 });


### PR DESCRIPTION
I was a bit heavy-handed with disabling of Sentry integrations and now the reports aren't very useful. This re-enables the ones that look like they'd be helpful for what we need.