### PR TITLE
Fix a handful of recent error reports

### DIFF
--- a/src/components/control/LocationInput/LocationInput.tsx
+++ b/src/components/control/LocationInput/LocationInput.tsx
@@ -43,11 +43,12 @@ export default class LocationInput extends Component<LocationInputProps> {
 
   autosuggest = async (query: string): Promise<HereMapsAutosuggestResult> => {
     try {
+      const safeQuery = encodeURIComponent(query);
       const apiKey = `apiKey=${this.apiKey}`;
       const bbox = `in=bbox:${this.boundingBox}`;
       const resultTypes = `result_types=${this.resultTypes}`;
       const response = await fetch(
-        `${this.autosuggestEndpoint}?q=${query}&${apiKey}&${bbox}&${resultTypes}`,
+        `${this.autosuggestEndpoint}?q=${safeQuery}&${apiKey}&${bbox}&${resultTypes}`,
       );
       return response.json();
     } catch (error) {

--- a/src/components/control/MaterialSearchInput/MaterialSearchInput.tsx
+++ b/src/components/control/MaterialSearchInput/MaterialSearchInput.tsx
@@ -152,11 +152,13 @@ export default class MaterialSearchInput extends Component<MaterialSearchInputPr
                 {open && showMaterials && (
                   <Combobox.Options static>
                     {materials.map((material) => {
-                      const displayName = material.name.replace(
-                        RegExp(escapeRegExp(this.inputValue.value), 'ig'),
-                        (match) =>
-                          `<span class="diamond-text-weight-bold">${match}</span>`,
-                      );
+                      const displayName = this.inputValue.value
+                        ? material.name.replace(
+                            RegExp(escapeRegExp(this.inputValue.value), 'ig'),
+                            (match) =>
+                              `<span class="diamond-text-weight-bold">${match}</span>`,
+                          )
+                        : material.name;
 
                       return (
                         <Combobox.Option

--- a/src/components/control/MaterialSearchInput/MaterialSearchInput.tsx
+++ b/src/components/control/MaterialSearchInput/MaterialSearchInput.tsx
@@ -2,6 +2,7 @@
 import { Combobox } from '@headlessui/react';
 import { Signal, signal } from '@preact/signals';
 import * as Sentry from '@sentry/browser';
+import escapeRegExp from 'lodash/escapeRegExp';
 import uniq from 'lodash/uniq';
 import { Component, createRef } from 'preact';
 import '@etchteam/diamond-ui/control/Input/Input';
@@ -152,7 +153,7 @@ export default class MaterialSearchInput extends Component<MaterialSearchInputPr
                   <Combobox.Options static>
                     {materials.map((material) => {
                       const displayName = material.name.replace(
-                        RegExp(this.inputValue.value, 'ig'),
+                        RegExp(escapeRegExp(this.inputValue.value), 'ig'),
                         (match) =>
                           `<span class="diamond-text-weight-bold">${match}</span>`,
                       );

--- a/src/components/control/PlacesMap/PlacesMap.tsx
+++ b/src/components/control/PlacesMap/PlacesMap.tsx
@@ -211,8 +211,12 @@ export default class PlacesMap extends Component<PlacesMapProps> {
   }
 
   componentWillUnmount() {
-    this.MapInstance.dispose();
-    window.removeEventListener('resize', this.resizeMap);
+    try {
+      this.MapInstance.dispose();
+      window.removeEventListener('resize', this.resizeMap);
+    } catch (error) {
+      // Ignore unmounting errors
+    }
   }
 
   componentDidUpdate(previousProps: Readonly<PlacesMapProps>) {

--- a/src/lib/getPropertiesByMaterial.ts
+++ b/src/lib/getPropertiesByMaterial.ts
@@ -15,7 +15,7 @@ function hasSchemeWithMaterial(
 
 export default function getPropertiesByMaterial(
   materialId: string,
-  properties: LocalAuthority['properties'],
+  properties: LocalAuthority['properties'] = {},
 ): LocalAuthority['properties'] | undefined {
   const propertyTypes = Object.keys(properties);
 

--- a/src/lib/sortPropertyTypes.ts
+++ b/src/lib/sortPropertyTypes.ts
@@ -3,7 +3,7 @@ import { LocalAuthority } from '@/types/locatorApi';
 import getPropertyTypeEnum from './getPropertyTypeEnum';
 
 export default function sortPropertyTypes(
-  properties: LocalAuthority['properties'],
+  properties: LocalAuthority['properties'] = {},
 ) {
   const PROPERTY_TYPE = getPropertyTypeEnum();
   const sortOrder = [

--- a/src/lib/useAnalytics.ts
+++ b/src/lib/useAnalytics.ts
@@ -33,7 +33,7 @@ async function sendAnalyticsRequest(event: AnalyticsEvent) {
 
   try {
     const query = new URLSearchParams(event as any);
-    await fetch(`${config.locatorAnalyticsPath}?${query}`, {
+    await fetch(encodeURI(`${config.locatorAnalyticsPath}?${query}`), {
       method: 'GET',
       headers: {
         'X-Requested-With': config.packageVersion,

--- a/src/pages/[postcode]/home/recycling-centre.page.tsx
+++ b/src/pages/[postcode]/home/recycling-centre.page.tsx
@@ -44,6 +44,7 @@ function HomeRecyclingCentrePageContent({
 }) {
   const { t } = useTranslation();
   const { postcode } = useParams();
+
   const hwrcLocations = locations.filter((location) =>
     location.locations.some((l) => l.locationType === 'HWRC'),
   );
@@ -167,9 +168,13 @@ export default function HomeRecyclingCentrePage() {
   return (
     <Suspense fallback={<Loading />}>
       <Await resolve={locationsPromise}>
-        {(locations) => (
-          <HomeRecyclingCentrePageContent locations={locations.items} />
-        )}
+        {(locations) => {
+          if (locations.error) {
+            throw new Error(locations.error);
+          }
+
+          return <HomeRecyclingCentrePageContent locations={locations.items} />;
+        }}
       </Await>
     </Suspense>
   );

--- a/src/pages/[postcode]/material/RecycleAtHome.tsx
+++ b/src/pages/[postcode]/material/RecycleAtHome.tsx
@@ -109,7 +109,7 @@ export default function RecycleAtHome({
   const PROPERTY_TYPE = getPropertyTypeEnum();
   const { postcode } = useParams();
   const { t } = useTranslation();
-  const allPropertyTypes = Object.keys(allProperties);
+  const allPropertyTypes = Object.keys(allProperties ?? {});
   const propertyTypesCollectingThisMaterial = Object.keys(
     propertiesCollectingThisMaterial ?? {},
   );

--- a/src/pages/[postcode]/places/map.page.tsx
+++ b/src/pages/[postcode]/places/map.page.tsx
@@ -55,9 +55,13 @@ export function PlacesMapPageContent({
   const fetcher = useFetcher() as FetcherWithComponents<PlacesLoaderResponse>;
   const fetchedLocations = fetcher.data?.locations;
   const locations = (fetchedLocations ?? loadedLocations) as LocationsResponse;
+
+  if (locations.error) {
+    throw new Error(locations.error);
+  }
+
   const defaultLatitude = locations.meta.latitude;
   const defaultLongitude = locations.meta.longitude;
-
   const activeLocation = useSignal<Location | null>(null);
   const showSearchThisArea = useSignal(false);
   const page = useSignal(1);

--- a/src/pages/[postcode]/places/places.layout.tsx
+++ b/src/pages/[postcode]/places/places.layout.tsx
@@ -30,7 +30,8 @@ export default function PlacesLayout({
   const { t } = useTranslation();
   const locale = i18n.language;
   const { postcode } = useParams();
-  const { locations: locationsPromise } = usePlacesLoaderData();
+  const loaderData = usePlacesLoaderData();
+  const locationsPromise = loaderData?.locations;
   const open = useSignal(false);
   const [searchParams, setSearchParams] = useSearchParams();
   const materialId = searchParams.get('materialId');

--- a/src/pages/[postcode]/places/places.page.tsx
+++ b/src/pages/[postcode]/places/places.page.tsx
@@ -80,6 +80,11 @@ function Places({
   // The loader is used initially then the fetcher is used to load more
   const fetchedLocations = fetcher.data?.locations;
   const locations = (fetchedLocations ?? loadedLocations) as LocationsResponse;
+
+  if (locations.error) {
+    throw new Error(locations.error);
+  }
+
   const count = locations.items.length;
   const showLocations = count > 0 && materialId !== 'undefined';
   const limit = locations.pagination.total;

--- a/src/types/locatorApi.ts
+++ b/src/types/locatorApi.ts
@@ -121,6 +121,7 @@ export interface LocationsResponse {
     page: number;
     total: number;
   };
+  error?: string;
 }
 
 export interface RecyclingMeta {


### PR DESCRIPTION
- Escape regex strings
- Avoid running regex if string is undefined
- Handle empty loader data for the places error route which shares a layout file
- Avoid uncaught errors related to the API responding with { error: 'message' } on the locations endpoint
- Handle empty la responses more gracefully by avoiding running an empty properties object through Object.keys (related to WRAP-634)
- Ignore here maps dispose errors
- Fix failed to fetch errors caused by sending an unencoded query to here maps auto-suggest endpoint, the analytics endpoint has also been encoded because the same error is appearing as coming from it 