### PR TITLE
Fix flash of unstyled icon

### DIFF
--- a/src/pages/entrypoint.tsx
+++ b/src/pages/entrypoint.tsx
@@ -37,13 +37,25 @@ const routes: RouteObject[] = [
   },
 ];
 
+/**
+ * A flash of this loading fallback often displays before styles or any components have had a
+ * chance to load. It'll be swapped out for the actual UI as soon as it's ready.
+ */
 function Loading() {
   return (
-    <locator-loading>
-      <locator-hero>
-        <locator-icon icon="distance" color="muted"></locator-icon>
-      </locator-hero>
-    </locator-loading>
+    <div
+      style={{
+        height: '100%',
+        width: '100%',
+        // minimum --container-height in case that hasn't loaded yet
+        minHeight: '540px',
+        // this border will blend in as a fallback in case border styles haven't loaded yet
+        border: 'var(--recycling-locator-container-border, 1px solid #cfd1d3)',
+        borderRadius: 'var(--recycling-locator-container-border-radius, 0)',
+        margin: '-1px -1px 0 -1px',
+        boxSizing: 'content-box',
+      }}
+    />
   );
 }
 

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -13,6 +13,7 @@ article {
 
 .recycling-locator-variant-widget {
   border: var(--container-border);
+  border-radius: var(--container-border-radius);
   box-sizing: content-box;
   height: var(--container-height);
 }

--- a/src/styles/tokens/container.css
+++ b/src/styles/tokens/container.css
@@ -7,6 +7,10 @@
     --recycling-locator-container-border,
     var(--container-border-default)
   );
+  --container-border-radius: var(
+    --recycling-locator-container-border-radius,
+    0
+  );
 
   /**
    * This matches the height setup in the optional FOUC preventing css file


### PR DESCRIPTION
First load occasionally showed a flash of an unstyled icon, this removes the icon and accounts for there being no styles loaded at all and applying minimal inline styles which expects to be displayed in a flash most of the time. 

It also adds support for a container border radius customisation.