### PR TITLE
Controlled font scaling

### DIFF
--- a/src/components/canvas/Hero/Hero.css
+++ b/src/components/canvas/Hero/Hero.css
@@ -13,7 +13,7 @@ locator-hero {
 
   /* small tablet */
   @container (width >= 600px) {
-    min-width: 20rem;
+    min-width: 20em;
   }
 
   h1,
@@ -26,7 +26,7 @@ locator-hero {
   locator-icon {
     color: var(--_icon-color);
     /* Giant icon just for the hero */
-    font-size: 3rem;
+    font-size: 3em;
     margin-block-end: var(--diamond-spacing);
   }
 

--- a/src/components/composition/Layout/Layout.css
+++ b/src/components/composition/Layout/Layout.css
@@ -86,7 +86,7 @@ locator-layout {
 
   [slot='layout-aside'] locator-places-map {
     /* Maps need to take up a minimum amount of space when placed in the layout aside */
-    min-height: 30rem;
+    min-height: 30em;
   }
 
   @container (width >= 768px) {

--- a/src/components/composition/PlacesHeader/PlacesHeader.css
+++ b/src/components/composition/PlacesHeader/PlacesHeader.css
@@ -49,7 +49,7 @@ locator-places-header {
       border-radius: var(--diamond-border-radius);
       margin-inline-end: var(--diamond-spacing);
       width: auto;
-      width: 18rem;
+      width: 18em;
     }
   }
 }

--- a/src/components/content/Logo/Logo.css
+++ b/src/components/content/Logo/Logo.css
@@ -1,7 +1,8 @@
 locator-logo {
   display: block;
   line-height: 1;
-  max-width: 100%;
+  max-width: 13.75em;
+  width: 100%;
 
   svg {
     display: block;

--- a/src/components/control/AlphabetNav/AlphabetNav.css
+++ b/src/components/control/AlphabetNav/AlphabetNav.css
@@ -1,11 +1,11 @@
 locator-alphabet-nav {
-  --_letter-size: 2rem;
+  --_letter-size: 2em;
   display: block;
 
   ul {
     display: flex;
     flex-wrap: wrap;
-    gap: 0.21rem; /* specific gap to avoid half a letter short line end */
+    gap: 0.21em; /* specific gap to avoid half a letter short line end */
     list-style: none;
     margin: 0;
     padding: 0;

--- a/src/components/control/TagButton/TagButton.css
+++ b/src/components/control/TagButton/TagButton.css
@@ -10,7 +10,7 @@ locator-tag-button {
     display: block;
     font-weight: bold;
     gap: var(--diamond-spacing-sm);
-    max-width: 13rem;
+    max-width: 13em;
     overflow: hidden;
     padding: var(--diamond-spacing-xs) var(--diamond-spacing-lg)
       var(--diamond-spacing-xs) var(--diamond-spacing-sm);

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -7,6 +7,7 @@
 article {
   background: var(--diamond-theme-background);
   container-type: inline-size;
+  font-size: var(--diamond-font-size-base);
   overflow-y: auto;
   position: relative;
 }

--- a/src/styles/diamond-ui.css
+++ b/src/styles/diamond-ui.css
@@ -1,5 +1,27 @@
 @import '../../node_modules/@etchteam/diamond-ui/diamond-ui.css';
 
+/* Override rem units */
+:host {
+  /* Ignore rem if host site html font-size is set to lower than 14px */
+  --diamond-font-size-base: max(14px, 0.875rem);
+
+  --diamond-font-size-default: 1em;
+  --diamond-font-size-h1: 2em;
+  --diamond-font-size-h2: 1.75em;
+  --diamond-font-size-h3: 1.5em;
+  --diamond-font-size-h4: 1.25em;
+  --diamond-spacing-thumb: 2.75em;
+  --diamond-spacing: 1em;
+}
+
+@media (width >= 768px) {
+  :host {
+    --diamond-font-size-base: max(14px, 1rem);
+    --diamond-font-size-h1: 3em;
+    --diamond-font-size-h2: 2em;
+  }
+}
+
 /**
   * Redefine body styles from diamond because we don't have a <body> element
   */

--- a/src/styles/tokens/button.css
+++ b/src/styles/tokens/button.css
@@ -1,4 +1,6 @@
 diamond-button {
+  --_size: 1em;
+
   --diamond-button-background: var(--color-white);
   --diamond-button-background-hover: var(--color-primary-lightest);
   --diamond-button-background-disabled: var(--diamond-button-background);
@@ -8,7 +10,7 @@ diamond-button {
   --diamond-button-color: var(--color-primary-dark);
   --diamond-button-color-hover: var(--color-primary-dark);
   --diamond-button-color-disabled: var(--color-primary);
-  --diamond-button-padding-block: 0.75rem;
+  --diamond-button-padding-block: 0.75em;
 
   --diamond-button-primary-background: var(--color-primary-dark);
   --diamond-button-primary-background-hover: color-mix(
@@ -36,5 +38,5 @@ diamond-button[variant='primary'] {
 }
 
 diamond-button[width='square'][size='sm'] {
-  --diamond-button-padding-block: 0.5rem;
+  --diamond-button-padding-block: 0.5em;
 }

--- a/src/styles/tokens/font.css
+++ b/src/styles/tokens/font.css
@@ -5,13 +5,13 @@
     var(--font-family-default)
   );
 
-  --diamond-font-size-h3: 1.5rem;
+  --diamond-font-size-h3: 1.5em;
 
   --diamond-icon-size: calc(1em * var(--diamond-font-line-height));
 }
 
 @media (width >= 768px) {
   :host {
-    --diamond-font-size-h2: 1.75rem;
+    --diamond-font-size-h2: 1.75em;
   }
 }

--- a/src/styles/tokens/header.css
+++ b/src/styles/tokens/header.css
@@ -1,3 +1,3 @@
 :host {
-  --header-height: 3.875rem;
+  --header-height: 3.875em;
 }


### PR DESCRIPTION
Avoids the font scaling lower than 14px when a lower value is used for the host sites root (HTML) element by
- Using the widget container as the parent element which provides the font size
- Moving all the most important bits within it to em instead of rem