### PR TITLE
Use current location

### DIFF
--- a/public/translations/cy.json
+++ b/public/translations/cy.json
@@ -129,6 +129,10 @@
     "title": "Dod o hyd i leoedd ailgylchu.",
     "label": "Ble’r ydych chi?",
     "cta": "Dechrau arni",
+    "geolocation": {
+      "label": "Defnyddiwch fy lleoliad",
+      "permission": "Angen caniatâd"
+    },
     "aside": {
       "paragraph": "Defnyddiwch y gwasanaeth hwn i:",
       "list": [

--- a/public/translations/en.json
+++ b/public/translations/en.json
@@ -129,6 +129,10 @@
     "title": "Find places to recycle.",
     "label": "Where are you?",
     "cta": "Get started",
+    "geolocation": {
+      "label": "Use my location",
+      "permission": "Requires permission"
+    },
     "aside": {
       "paragraph": "Use this service to:",
       "list": [

--- a/src/components/canvas/Highlight/Highlight.css
+++ b/src/components/canvas/Highlight/Highlight.css
@@ -1,0 +1,9 @@
+locator-highlight {
+  background: var(--diamond-theme-background, --theme-background-info);
+  border-radius: var(--diamond-border-radius);
+  color: var(--diamond-theme-color, --theme-color-info);
+  display: inline-block;
+  padding: var(--diamond-spacing-xs) var(--diamond-spacing-sm);
+  transition: background var(--diamond-transition) color
+    var(--diamond-transition);
+}

--- a/src/components/canvas/Highlight/Highlight.stories.tsx
+++ b/src/components/canvas/Highlight/Highlight.stories.tsx
@@ -1,0 +1,35 @@
+import { Meta, StoryObj } from '@storybook/preact';
+
+import './Highlight';
+
+const meta: Meta = {
+  title: 'Components/Canvas/Highlight',
+};
+
+export default meta;
+
+export const Highlight: StoryObj = {
+  render: () => <locator-highlight>Highlighted text</locator-highlight>,
+};
+
+export const Info: StoryObj = {
+  render: () => (
+    <locator-highlight className="theme-info">Info text</locator-highlight>
+  ),
+};
+
+export const Positive: StoryObj = {
+  render: () => (
+    <locator-highlight className="theme-positive">
+      Positive text
+    </locator-highlight>
+  ),
+};
+
+export const Negative: StoryObj = {
+  render: () => (
+    <locator-highlight className="theme-negative">
+      Negative text
+    </locator-highlight>
+  ),
+};

--- a/src/components/canvas/Highlight/Highlight.tsx
+++ b/src/components/canvas/Highlight/Highlight.tsx
@@ -1,0 +1,9 @@
+import { CustomElement } from '@/types/customElement';
+
+declare module 'react' {
+  namespace JSX {
+    interface IntrinsicElements {
+      'locator-highlight': CustomElement;
+    }
+  }
+}

--- a/src/components/control/LocationInput/LocationInput.tsx
+++ b/src/components/control/LocationInput/LocationInput.tsx
@@ -21,6 +21,7 @@ interface LocationInputProps {
   readonly placeholder?: string;
   readonly valid?: boolean;
   readonly autofocus?: boolean;
+  readonly disabled?: boolean;
   readonly handleBlur?: (value: string) => void;
   readonly handleInput?: (value: string) => void;
 }
@@ -91,6 +92,7 @@ export default class LocationInput extends Component<LocationInputProps> {
             type="text"
             name="location"
             autoFocus={this.props.autofocus}
+            disabled={this.props.disabled}
             autoComplete="street-address"
             placeholder={placeholder}
             id={inputId}

--- a/src/pages/LocationForm.tsx
+++ b/src/pages/LocationForm.tsx
@@ -9,9 +9,12 @@ import {
   useSubmit,
 } from 'react-router-dom';
 import '@etchteam/diamond-ui/composition/FormGroup/FormGroup';
+import '@etchteam/diamond-ui/composition/Grid/Grid';
+import '@etchteam/diamond-ui/composition/Grid/GridItem';
 import '@etchteam/diamond-ui/control/Button/Button';
 import '@etchteam/diamond-ui/control/RadioCheckbox/RadioCheckbox';
 
+import '@/components/canvas/Highlight/Highlight';
 import LocationInput from '@/components/control/LocationInput/LocationInput';
 import { useAppState } from '@/lib/AppState';
 import useFormValidation from '@/lib/useFormValidation';
@@ -83,39 +86,43 @@ export default function LocationForm({
         ></LocationInput>
       </diamond-form-group>
       {isStandalone && (
-        <>
-          <diamond-radio-checkbox
-            state={geolocationError.value ? 'invalid' : undefined}
-            className="diamond-spacing-bottom-md diamond-text-size-sm"
-          >
-            <label>
-              <input
-                type="checkbox"
-                name="geolocation"
-                value="yes"
-                onChange={(event) =>
-                  (geolocation.value = (
-                    event.target as HTMLInputElement
-                  ).checked)
-                }
-                aria-invalid={geolocationError.value}
-                aria-errormessage={
-                  geolocationError.value ? 'geolocation-error' : undefined
-                }
-              />
-              {t('start.geolocation.label')}
-            </label>
-          </diamond-radio-checkbox>
-          {geolocationError.value && (
-            <p
+        <diamond-grid
+          align-items="center"
+          className="diamond-spacing-bottom-md"
+        >
+          <diamond-grid-item grow shrink>
+            <diamond-radio-checkbox
+              state={geolocationError.value ? 'invalid' : undefined}
+              className="diamond-text-size-sm"
+            >
+              <label>
+                <input
+                  type="checkbox"
+                  name="geolocation"
+                  value="yes"
+                  onChange={(event) =>
+                    (geolocation.value = (
+                      event.target as HTMLInputElement
+                    ).checked)
+                  }
+                  aria-invalid={geolocationError.value}
+                  aria-errormessage={
+                    geolocationError.value ? 'geolocation-error' : undefined
+                  }
+                />
+                {t('start.geolocation.label')}
+              </label>
+            </diamond-radio-checkbox>
+          </diamond-grid-item>
+          <diamond-grid-item>
+            <locator-highlight
               id="geolocation-error"
-              className="text-color-negative diamond-text-size-sm diamond-spacing-top-xs"
-              aria-live="polite"
+              className={`diamond-text-size-xs ${geolocationError.value ? 'theme-negative' : 'theme-info'}`}
             >
               {t('start.geolocation.permission')}
-            </p>
-          )}
-        </>
+            </locator-highlight>
+          </diamond-grid-item>
+        </diamond-grid>
       )}
       {children}
       <diamond-button width="full-width" variant="primary">

--- a/src/pages/LocationForm.tsx
+++ b/src/pages/LocationForm.tsx
@@ -1,11 +1,19 @@
+import { useSignal } from '@preact/signals';
 import { ComponentChildren } from 'preact';
 import { useEffect } from 'preact/hooks';
 import { useTranslation } from 'react-i18next';
-import { Form, useLocation, useSearchParams } from 'react-router-dom';
+import {
+  Form,
+  useLocation,
+  useSearchParams,
+  useSubmit,
+} from 'react-router-dom';
 import '@etchteam/diamond-ui/composition/FormGroup/FormGroup';
 import '@etchteam/diamond-ui/control/Button/Button';
+import '@etchteam/diamond-ui/control/RadioCheckbox/RadioCheckbox';
 
 import LocationInput from '@/components/control/LocationInput/LocationInput';
+import { useAppState } from '@/lib/AppState';
 import useFormValidation from '@/lib/useFormValidation';
 
 export default function LocationForm({
@@ -24,22 +32,91 @@ export default function LocationForm({
   const form = useFormValidation('location');
   const [searchParams] = useSearchParams();
   const autofocus = searchParams.get('autofocus') === 'true';
+  const geolocation = useSignal(false);
+  const geolocationError = useSignal(false);
+  const submit = useSubmit();
+  const app = useAppState();
+  const isStandalone = app.variant === 'standalone';
 
   useEffect(() => {
     form.submitting.value = false;
   }, [location]);
 
+  function handleSubmit(event) {
+    geolocationError.value = false;
+
+    if (!geolocation.value) {
+      return form.handleSubmit(event);
+    }
+
+    event.preventDefault();
+    form.submitting.value = true;
+    const locationForm = event?.submitter?.form ?? undefined;
+    const checkbox = locationForm?.querySelector('input[name="geolocation"]');
+    const formData = new FormData(locationForm);
+
+    navigator.geolocation.getCurrentPosition(
+      ({ coords }) => {
+        formData.set('lat', coords.latitude.toString());
+        formData.set('lng', coords.longitude.toString());
+        submit(formData, { method: 'post', action });
+      },
+      () => {
+        geolocation.value = false;
+        form.submitting.value = false;
+        checkbox.checked = false;
+        geolocationError.value = true;
+      },
+    );
+  }
+
   return (
-    <Form action={action} method="post" onSubmit={form.handleSubmit}>
+    <Form action={action} method="post" onSubmit={handleSubmit}>
       <diamond-form-group className="diamond-spacing-bottom-md">
         <label htmlFor="location-input">{label ?? t('start.label')}</label>
         <LocationInput
           autofocus={autofocus}
           handleBlur={form.handleBlur}
           handleInput={form.handleInput}
-          valid={form.valid.value}
+          disabled={geolocation.value}
+          valid={form.valid.value || geolocation.value}
         ></LocationInput>
       </diamond-form-group>
+      {isStandalone && (
+        <>
+          <diamond-radio-checkbox
+            state={geolocationError.value ? 'invalid' : undefined}
+            className="diamond-spacing-bottom-md diamond-text-size-sm"
+          >
+            <label>
+              <input
+                type="checkbox"
+                name="geolocation"
+                value="yes"
+                onChange={(event) =>
+                  (geolocation.value = (
+                    event.target as HTMLInputElement
+                  ).checked)
+                }
+                aria-invalid={geolocationError.value}
+                aria-errormessage={
+                  geolocationError.value ? 'geolocation-error' : undefined
+                }
+              />
+              {t('start.geolocation.label')}
+            </label>
+          </diamond-radio-checkbox>
+          {geolocationError.value && (
+            <p
+              id="geolocation-error"
+              className="text-color-negative diamond-text-size-sm diamond-spacing-top-xs"
+              aria-live="polite"
+            >
+              {t('start.geolocation.permission')}
+            </p>
+          )}
+        </>
+      )}
       {children}
       <diamond-button width="full-width" variant="primary">
         <button type="submit" disabled={form.submitting.value}>

--- a/src/pages/start.action.ts
+++ b/src/pages/start.action.ts
@@ -23,7 +23,7 @@ export async function resolvePostcode(formData: FormData) {
   const location = formData.get('location') as string;
   const lat = Number(formData.get('lat'));
   const lng = Number(formData.get('lng'));
-  console.log(lat, lng, location);
+
   if (lat && lng) {
     return PostCodeResolver.fromLatLng(lat, lng);
   }

--- a/src/pages/start.action.ts
+++ b/src/pages/start.action.ts
@@ -21,6 +21,13 @@ function handleError(error: Error) {
 
 export async function resolvePostcode(formData: FormData) {
   const location = formData.get('location') as string;
+  const lat = Number(formData.get('lat'));
+  const lng = Number(formData.get('lng'));
+  console.log(lat, lng, location);
+  if (lat && lng) {
+    return PostCodeResolver.fromLatLng(lat, lng);
+  }
+
   return PostCodeResolver.fromString(location);
 }
 

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -7,6 +7,7 @@
 
 @import './tokens/border.css';
 @import './tokens/button.css';
+@import './tokens/checkbox.css';
 @import './tokens/color.css';
 @import './tokens/container.css';
 @import './tokens/font.css';

--- a/src/styles/tokens/checkbox.css
+++ b/src/styles/tokens/checkbox.css
@@ -1,0 +1,3 @@
+:host {
+  --diamond-input-checked: var(--color-primary-dark);
+}


### PR DESCRIPTION
- Use my location checkbox for standalone app only
- Whilst the checkbox is checked location entry is disabled
- If permissions granted the app gets postcode by lat lng instead of location upon form submission
- If permissions are not granted an error state is displayed and the form reset

Sonarcloud has raised a security alert doesn't want us to include geolocation but it's completely optional convenience 

https://github.com/etchteam/recycling-locator/assets/5038459/e548b069-b567-452a-8d13-97783c35bec2

