### PR TITLE
Open standalone app in a new tab

### DIFF
--- a/public/translations/cy.json
+++ b/public/translations/cy.json
@@ -133,6 +133,10 @@
       "label": "Defnyddiwch fy lleoliad",
       "permission": "Angen caniatâd"
     },
+    "newTab": {
+      "label": "Parhewch mewn tab newydd",
+      "bestExperience": "Profiad gorau"
+    },
     "aside": {
       "paragraph": "Defnyddiwch y gwasanaeth hwn i:",
       "list": [

--- a/public/translations/en.json
+++ b/public/translations/en.json
@@ -133,6 +133,10 @@
       "label": "Use my location",
       "permission": "Requires permission"
     },
+    "newTab": {
+      "label": "Continue in a new tab",
+      "bestExperience": "Best experience"
+    },
     "aside": {
       "paragraph": "Use this service to:",
       "list": [

--- a/src/pages/LocationForm.tsx
+++ b/src/pages/LocationForm.tsx
@@ -76,6 +76,7 @@ export default function LocationForm({
 
   return (
     <Form action={action} method="post" onSubmit={handleSubmit}>
+      <input type="hidden" name="locale" value={app.locale} />
       <diamond-form-group className="diamond-spacing-bottom-md">
         <label htmlFor="location-input">{label ?? t('start.label')}</label>
         <LocationInput
@@ -91,7 +92,7 @@ export default function LocationForm({
           align-items="center"
           className="diamond-spacing-bottom-md"
         >
-          <diamond-grid-item grow shrink>
+          <diamond-grid-item>
             <diamond-radio-checkbox
               state={geolocationError.value ? 'invalid' : undefined}
               className="diamond-text-size-sm"
@@ -129,7 +130,7 @@ export default function LocationForm({
           align-items="center"
           className="diamond-spacing-bottom-md"
         >
-          <diamond-grid-item grow shrink>
+          <diamond-grid-item>
             <diamond-radio-checkbox className="diamond-text-size-sm">
               <label>
                 <input
@@ -145,7 +146,7 @@ export default function LocationForm({
             </diamond-radio-checkbox>
           </diamond-grid-item>
           <diamond-grid-item>
-            <locator-highlight className="diamond-text-size-xs theme-info">
+            <locator-highlight className="diamond-text-size-xs theme-positive">
               {t('start.newTab.bestExperience')}
             </locator-highlight>
           </diamond-grid-item>

--- a/src/pages/LocationForm.tsx
+++ b/src/pages/LocationForm.tsx
@@ -37,7 +37,6 @@ export default function LocationForm({
   const autofocus = searchParams.get('autofocus') === 'true';
   const geolocation = useSignal(false);
   const geolocationError = useSignal(false);
-  const newTab = useSignal(false);
   const submit = useSubmit();
   const app = useAppState();
   const isStandalone = app.variant === 'standalone';
@@ -133,14 +132,7 @@ export default function LocationForm({
           <diamond-grid-item>
             <diamond-radio-checkbox className="diamond-text-size-sm">
               <label>
-                <input
-                  type="checkbox"
-                  name="new-tab"
-                  value="yes"
-                  onChange={(event) =>
-                    (newTab.value = (event.target as HTMLInputElement).checked)
-                  }
-                />
+                <input type="checkbox" name="new-tab" value="yes" />
                 {t('start.newTab.label')}
               </label>
             </diamond-radio-checkbox>

--- a/src/pages/LocationForm.tsx
+++ b/src/pages/LocationForm.tsx
@@ -37,6 +37,7 @@ export default function LocationForm({
   const autofocus = searchParams.get('autofocus') === 'true';
   const geolocation = useSignal(false);
   const geolocationError = useSignal(false);
+  const newTab = useSignal(false);
   const submit = useSubmit();
   const app = useAppState();
   const isStandalone = app.variant === 'standalone';
@@ -85,7 +86,7 @@ export default function LocationForm({
           valid={form.valid.value || geolocation.value}
         ></LocationInput>
       </diamond-form-group>
-      {isStandalone && (
+      {isStandalone ? (
         <diamond-grid
           align-items="center"
           className="diamond-spacing-bottom-md"
@@ -120,6 +121,32 @@ export default function LocationForm({
               className={`diamond-text-size-xs ${geolocationError.value ? 'theme-negative' : 'theme-info'}`}
             >
               {t('start.geolocation.permission')}
+            </locator-highlight>
+          </diamond-grid-item>
+        </diamond-grid>
+      ) : (
+        <diamond-grid
+          align-items="center"
+          className="diamond-spacing-bottom-md"
+        >
+          <diamond-grid-item grow shrink>
+            <diamond-radio-checkbox className="diamond-text-size-sm">
+              <label>
+                <input
+                  type="checkbox"
+                  name="new-tab"
+                  value="yes"
+                  onChange={(event) =>
+                    (newTab.value = (event.target as HTMLInputElement).checked)
+                  }
+                />
+                {t('start.newTab.label')}
+              </label>
+            </diamond-radio-checkbox>
+          </diamond-grid-item>
+          <diamond-grid-item>
+            <locator-highlight className="diamond-text-size-xs theme-info">
+              {t('start.newTab.bestExperience')}
             </locator-highlight>
           </diamond-grid-item>
         </diamond-grid>

--- a/src/pages/LocationForm.tsx
+++ b/src/pages/LocationForm.tsx
@@ -17,6 +17,7 @@ import '@etchteam/diamond-ui/control/RadioCheckbox/RadioCheckbox';
 import '@/components/canvas/Highlight/Highlight';
 import LocationInput from '@/components/control/LocationInput/LocationInput';
 import { useAppState } from '@/lib/AppState';
+import i18n from '@/lib/i18n';
 import useFormValidation from '@/lib/useFormValidation';
 
 export default function LocationForm({
@@ -39,6 +40,7 @@ export default function LocationForm({
   const geolocationError = useSignal(false);
   const submit = useSubmit();
   const app = useAppState();
+  const locale = i18n.language;
   const isStandalone = app.variant === 'standalone';
 
   useEffect(() => {
@@ -75,7 +77,7 @@ export default function LocationForm({
 
   return (
     <Form action={action} method="post" onSubmit={handleSubmit}>
-      <input type="hidden" name="locale" value={app.locale} />
+      <input type="hidden" name="locale" value={locale} />
       <diamond-form-group className="diamond-spacing-bottom-md">
         <label htmlFor="location-input">{label ?? t('start.label')}</label>
         <LocationInput

--- a/src/pages/start.action.ts
+++ b/src/pages/start.action.ts
@@ -19,7 +19,7 @@ function handleError(error: Error) {
   throw error;
 }
 
-export async function resolvePostcode(formData: FormData) {
+function resolvePostcode(formData: FormData) {
   const location = formData.get('location') as string;
   const lat = Number(formData.get('lat'));
   const lng = Number(formData.get('lng'));
@@ -31,13 +31,32 @@ export async function resolvePostcode(formData: FormData) {
   return PostCodeResolver.fromString(location);
 }
 
+async function handleRedirect(formData: FormData, path = '') {
+  const postcode = await resolvePostcode(formData);
+  const openInNewTab = formData.get('new-tab') === 'yes';
+  const route = `/${postcode}${path}`;
+
+  if (openInNewTab) {
+    const locale = formData.get('locale') as string;
+    const domain =
+      locale === 'cy' || window.location.host.includes('walesrecycles.org.uk')
+        ? 'locator.walesrecycles.org.uk'
+        : 'locator.recyclenow.com';
+    const url = new URL(`https://${domain}${route}`);
+    url.searchParams.set('locale', locale);
+    window.open(url, '_blank').focus();
+  }
+
+  return redirect(route);
+}
+
 export async function homeRecyclingStartAction({
   request,
 }: ActionFunctionArgs) {
   try {
     const formData = await request.formData();
-    const postcode = await resolvePostcode(formData);
-    return redirect(`/${postcode}/home`);
+    const response = await handleRedirect(formData, '/home');
+    return response;
   } catch (error) {
     handleError(error);
   }
@@ -46,13 +65,16 @@ export async function homeRecyclingStartAction({
 export async function materialStartAction({ request }: ActionFunctionArgs) {
   try {
     const formData = await request.formData();
-    const postcode = await resolvePostcode(formData);
     const searchParams = mapSearchParams(
       ['materials', 'category', 'search'],
       formData,
     );
 
-    return redirect(`/${postcode}/material?${searchParams.toString()}`);
+    const response = await handleRedirect(
+      formData,
+      `/material?${searchParams.toString()}`,
+    );
+    return response;
   } catch (error) {
     handleError(error);
   }
@@ -61,8 +83,8 @@ export async function materialStartAction({ request }: ActionFunctionArgs) {
 export default async function startAction({ request }: ActionFunctionArgs) {
   try {
     const formData = await request.formData();
-    const postcode = await resolvePostcode(formData);
-    return redirect(`/${postcode}`);
+    const response = await handleRedirect(formData);
+    return response;
   } catch (error) {
     handleError(error);
   }

--- a/src/pages/start.action.ts
+++ b/src/pages/start.action.ts
@@ -45,6 +45,7 @@ async function handleRedirect(formData: FormData, path = '') {
     const url = new URL(`https://${domain}${route}`);
     url.searchParams.set('locale', locale);
     window.open(url, '_blank').focus();
+    return new Response(null, { status: 204 });
   }
 
   return redirect(route);

--- a/src/styles/tokens/color.css
+++ b/src/styles/tokens/color.css
@@ -17,6 +17,7 @@
   --color-blue-light: #bee9f6;
   --color-blue: #059bdc;
   --color-blue-dark: #0077ab;
+  --color-blue-darkest: #00567a;
 
   --color-yellow-lightest: #fffacf;
   --color-yellow-light: #ffe9a5;

--- a/src/styles/tokens/theme.css
+++ b/src/styles/tokens/theme.css
@@ -39,8 +39,8 @@
   --theme-background-info-muted: var(--color-blue-lightest);
   --theme-background-info: var(--color-blue-lightest);
   --theme-heading-color-info: var(--color-blue-dark);
-  --theme-color-info: var(--color-blue-dark);
-  --theme-link-color-info: var(--color-blue-dark);
+  --theme-color-info: var(--color-blue-darkest);
+  --theme-link-color-info: var(--color-blue-darkest);
 
   --theme-background-positive-muted: var(--color-green-light);
   --theme-background-positive: var(--color-green);

--- a/tests/end-to-end/start.test.ts
+++ b/tests/end-to-end/start.test.ts
@@ -27,7 +27,7 @@ describeEndToEndTest('Start page', () => {
       route.fulfill({ json: GuernseyGeocodeResponse });
     });
 
-    const input = page.locator('input').first();
+    const input = page.locator('input[type="text"]').first();
     const notInUk = page.getByText(t('notFound.title.notInTheUK')).first();
     await expect(input).toBeVisible();
     await expect(notInUk).not.toBeVisible();
@@ -43,7 +43,7 @@ describeEndToEndTest('Start page', () => {
       route.fulfill({ json: PostcodeGeocodeResponse });
     });
 
-    const input = page.locator('input').first();
+    const input = page.locator('input[type="text"]').first();
     const postcode = page.getByText('EX32 7RB').first();
     const city = page.getByText('Barnstaple').first();
     const postcodePageTitle = page.getByText(t('postcode.title')).first();
@@ -68,7 +68,7 @@ describeEndToEndTest('Start page', () => {
       route.fulfill({ json: ValidPostcodeResponse });
     });
 
-    const input = page.locator('input').first();
+    const input = page.locator('input[type="text"]').first();
     const postcode = page.getByText('EX32 7RB').first();
     const city = page.getByText('Barnstaple').first();
     const postcodePageTitle = page.getByText(t('postcode.title')).first();
@@ -94,7 +94,7 @@ describeEndToEndTest('Start page', () => {
       route.fulfill({ json: InvalidPostcodeResponse });
     });
 
-    const input = page.locator('input').first();
+    const input = page.locator('input[type="text"]').first();
     const postcode = page.getByText('EX32 7RB').first();
     const city = page.getByText('Barnstaple').first();
     const notFoundPageTitle = page
@@ -124,7 +124,7 @@ describeEndToEndTest('Start page', () => {
       route.fulfill({ json: LocalAuthorityResponse });
     });
 
-    const input = page.locator('input').first();
+    const input = page.locator('input[type="text"]').first();
     const homeStartPageTitle = page
       .getByText(t('start.homeRecycling.title'))
       .first();
@@ -168,7 +168,7 @@ describeEndToEndTest('Start page', () => {
       route.fulfill({ json: LocationsResponse });
     });
 
-    const input = page.locator('input').first();
+    const input = page.locator('input[type="text"]').first();
     const materialStartPageTitle = page
       .getByText(
         t('start.material.title', { material: 'Plastic drinks bottles' }),


### PR DESCRIPTION
Adds a checkbox to the start page location form so people can open the locator in full screen standalone app mode.

![Screenshot 2024-05-28 at 16 08 34](https://github.com/etchteam/recycling-locator/assets/5038459/4a641173-8fb8-4860-8c9c-3b7e26c6708f)

This will send an empty response back to the current tab so the widget will be left as it was when the form got submitted instead of returning the usual redirect response which would double up the page view in analytics.

If the user is on Wales Recycles or is viewing the cy version of the locator this will open locator.walesrecycles.org.uk instead of locator.recyclenow.com

Note I don't know what megalinter is complaining about, none of the dependencies it's warning about have changed...