### PR TITLE
Send feedback as analytics events

### DIFF
--- a/public/translations/cy.json
+++ b/public/translations/cy.json
@@ -92,7 +92,7 @@
       "comment": {
         "label": "Gadewch sylw i egluro pam.",
         "placeholder": "Ychwanegwch eich meddyliau...",
-        "error": "Rhowch sylw"
+        "error": "Rhowch sylw gydag uchafswm o 250 nod"
       },
       "result": {
         "positive": "Rydych chi'n hoffi hyn!",

--- a/public/translations/en.json
+++ b/public/translations/en.json
@@ -92,7 +92,7 @@
       "comment": {
         "label": "Please leave a comment to explain why.",
         "placeholder": "Add your thoughts...",
-        "error": "Please enter a comment"
+        "error": "Enter a comment with a maximum of 250 characters"
       },
       "result": {
         "positive": "You like this!",

--- a/src/components/control/MaterialSearchInput/MaterialSearchInput.tsx
+++ b/src/components/control/MaterialSearchInput/MaterialSearchInput.tsx
@@ -29,6 +29,7 @@ interface MaterialSearchInputProps {
   readonly defaultValue?: string;
   readonly valid?: boolean;
   readonly autofocus?: boolean;
+  readonly includeFeedbackForm?: boolean;
   readonly handleBlur?: (value: string) => void;
   readonly handleInput?: (value: string) => void;
   readonly handleReset?: () => void;
@@ -230,7 +231,7 @@ export default class MaterialSearchInput extends Component<MaterialSearchInputPr
               : i18n.t('components.materialSearchInput.error')}
           </p>
         )}
-        {materialNotFound && (
+        {materialNotFound && this.props.includeFeedbackForm && (
           <ReportMissingMaterial
             missingMaterial={this.materialNotFound.value}
           />

--- a/src/components/control/RateThisInfo/RateThisInfo.css
+++ b/src/components/control/RateThisInfo/RateThisInfo.css
@@ -106,5 +106,20 @@ locator-rate-this-info {
       font-size: var(--diamond-font-size-sm);
       justify-content: center;
     }
+
+    diamond-input {
+      /* extra space for the count */
+      padding-block-end: var(--diamond-spacing);
+      /* position context for the count */
+      position: relative;
+    }
+
+    span {
+      bottom: 0;
+      font-size: var(--diamond-font-size-xs);
+      pointer-events: none;
+      position: absolute;
+      right: 0;
+    }
   }
 }

--- a/src/components/control/ReportMissingMaterial/ReportMissingMaterial.tsx
+++ b/src/components/control/ReportMissingMaterial/ReportMissingMaterial.tsx
@@ -12,6 +12,7 @@ import '@/components/composition/IconText/IconText';
 import '@/components/content/Icon/Icon';
 
 import LocatorApi from '@/lib/LocatorApi';
+import useAnalytics from '@/lib/useAnalytics';
 import { CustomElement } from '@/types/customElement';
 import { MaterialCategory } from '@/types/locatorApi';
 
@@ -27,6 +28,7 @@ export default function ReportMissingMaterial({
   const selectedCategory = useSignal<string | null>(null);
   const showCategoryError = useSignal(false);
   const hasSubmittedFeedback = useSignal(false);
+  const { recordEvent } = useAnalytics();
 
   useEffect(() => {
     // Reset the form state when the missing material changes
@@ -63,8 +65,11 @@ export default function ReportMissingMaterial({
       return;
     }
 
-    // @TODO: Need somewhere to send this feedback to
-    console.log(missingMaterial, selectedCategory.value);
+    recordEvent({
+      category: 'Material::Feedback',
+      action: `Missing material: ${missingMaterial}, Suggested category: ${selectedCategory.value}`,
+    });
+
     hasSubmittedFeedback.value = true;
     feedbackFormOpen.value = false;
   }, []);

--- a/src/pages/[postcode]/material/search.page.tsx
+++ b/src/pages/[postcode]/material/search.page.tsx
@@ -68,6 +68,7 @@ export default function MaterialSearchPage() {
                     handleInput={form.handleInput}
                     submitting={form.submitting.value}
                     valid={form.valid.value}
+                    includeFeedbackForm
                   ></MaterialSearchInput>
                 </diamond-form-group>
               </Form>

--- a/src/pages/[postcode]/places/search/search.page.tsx
+++ b/src/pages/[postcode]/places/search/search.page.tsx
@@ -49,6 +49,7 @@ export default function PlacesSearchPage() {
                 handleInput={form.handleInput}
                 submitting={form.submitting.value}
                 valid={form.valid.value}
+                includeFeedbackForm
               ></MaterialSearchInput>
             </diamond-form-group>
           </Form>

--- a/src/pages/[postcode]/postcode.page.tsx
+++ b/src/pages/[postcode]/postcode.page.tsx
@@ -150,6 +150,7 @@ export default function PostcodePage() {
                 handleInput={form.handleInput}
                 submitting={form.submitting.value}
                 valid={form.valid.value}
+                includeFeedbackForm
               ></MaterialSearchInput>
             </Form>
           </diamond-enter>


### PR DESCRIPTION
Sending rate this info and report a missing material as analytics events.

To aid with use of this, I've spruced up the [analytics docs](https://www.notion.so/etchteam/Analytics-0596dab639e9477bab0f9b42017c5506?pvs=4).

And added a character limit of 250 to the comment box so it won't exceed the maximum URL 2048 character limit.

The [maximum row size in BigQuery is 100mb](https://cloud.google.com/bigquery/quotas) so I assume storing the comment won't be a problem.

https://github.com/etchteam/recycling-locator/assets/5038459/298decab-c04e-4375-8b88-3e146c755ef9

