### PR TITLE
Retain search context between places list and details

### DIFF
--- a/src/pages/[postcode]/places/map.page.tsx
+++ b/src/pages/[postcode]/places/map.page.tsx
@@ -187,7 +187,7 @@ export function PlacesMapPageContent({
               <diamond-grid-item small-mobile="6">
                 <diamond-button width="full-width" variant="primary" size="sm">
                   <Link
-                    to={`/${postcode}/places/${activeLocationName}/${activeLocationPostcode}`}
+                    to={`/${postcode}/places/${activeLocationName}/${activeLocationPostcode}?${searchParams.toString()}`}
                   >
                     {t('actions.viewDetails')}
                   </Link>

--- a/src/pages/[postcode]/places/places.page.tsx
+++ b/src/pages/[postcode]/places/places.page.tsx
@@ -94,6 +94,8 @@ function Places({
   const currentPage = limit / 30;
   const maxLimit = 120;
   const showLoadMore = showLocations && count >= limit && limit !== maxLimit;
+  const locationSearchParams = new URLSearchParams(searchParams);
+  locationSearchParams.set('page', String(currentPage));
 
   const handleResetSearch = () => {
     searchParams.delete('materials');
@@ -150,7 +152,7 @@ function Places({
                   return (
                     <li key={`${location.id}`}>
                       <Link
-                        to={`/${postcode}/places/${locationName}/${locationPostcode}`}
+                        to={`/${postcode}/places/${locationName}/${locationPostcode}?${locationSearchParams.toString()}`}
                       >
                         <diamond-enter type="fade">
                           <diamond-card border radius>


### PR DESCRIPTION
Passes the query params between listing page or map to place details and back so that searches aren't lost during navigation between these views.

Includes a small refactor to pull the place details map into a separate component in order to avoid repeating the URL.