### PR TITLE
Increase limit for nearby HWRC search

### DIFF
--- a/src/pages/[postcode]/home/recycling-centre.loader.ts
+++ b/src/pages/[postcode]/home/recycling-centre.loader.ts
@@ -11,7 +11,9 @@ export default async function homeRecyclingCentreLoader({
   params,
 }: LoaderFunctionArgs) {
   const postcode = params.postcode;
-  const locations = LocatorApi.get<LocationsResponse>(`locations/${postcode}`);
+  const locations = LocatorApi.get<LocationsResponse>(
+    `locations/${postcode}?limit=120&radius=25`,
+  );
 
   return {
     locations: locations,


### PR DESCRIPTION
This is a partial fix for finding nearby HWRCs, by increasing the limit of locations we increase the likelihood that a HWRC will be returned.

The full fix is explained in the [highlight HWRC scope](https://etchteam.notion.site/Highlight-HWRC-155603d1ca4749b08ba1b37516ac76fd?pvs=4).