### PR TITLE
Fix dispatchEvent on undefined and missing icon alerts

### DIFF
--- a/src/components/content/Icon/Icon.tsx
+++ b/src/components/content/Icon/Icon.tsx
@@ -42,6 +42,10 @@ export interface IconAttributes {
 }
 
 export default function Icon({ icon, label }: IconAttributes) {
+  if (!icon) {
+    return null;
+  }
+
   const IconSvg = lazy(() => {
     return import(`./svg/${icon}.svg?react`).catch((error) => {
       Sentry.captureException(error, {

--- a/src/pages/root.layout.tsx
+++ b/src/pages/root.layout.tsx
@@ -41,7 +41,7 @@ export default function RootLayout() {
   // this is delayed by 50ms to give the outer page time to add an event listener
   setTimeout(() => {
     const host = document.querySelector('recycling-locator');
-    host.dispatchEvent(new CustomEvent('ready'));
+    host?.dispatchEvent(new CustomEvent('ready'));
   }, 50);
 
   return <Outlet />;


### PR DESCRIPTION
- [null is not an object (evaluating 'document.querySelector("recycling-locator").dispatchEvent')](https://wrap.sentry.io/issues/5547727283/?referrer=slack&notification_uuid=6ba042d8-6144-4627-9452-2b43a8b2d017&alert_rule_id=12711401&alert_type=issue)
  - Handled via optional coalescing
  - Guess is that it could be null in some environments where document isn't defined yet
- [Unknown variable dynamic import: ./svg/undefined.svg](https://wrap.sentry.io/issues/5542649338/?referrer=slack&notification_uuid=c7345180-cb25-4490-8924-f498c58c08f9&alert_rule_id=15082034&alert_type=issue)
  - Handled by returning null before the catch block if the icon is undefined
  - I've run through the codebase and can't find any instances where the icon could be undefined
  - Guess is that this is some kind of Safari browser web component loading quirk as I never see icons that don't load