### PR TITLE
Fix missing icon alerts, attempt 2

### DIFF
--- a/src/components/content/Icon/Icon.tsx
+++ b/src/components/content/Icon/Icon.tsx
@@ -42,7 +42,7 @@ export interface IconAttributes {
 }
 
 export default function Icon({ icon, label }: IconAttributes) {
-  if (!icon) {
+  if (!icon || (icon as string) === 'undefined') {
     return null;
   }
 


### PR DESCRIPTION
We're still getting the missing icon alerts that should have been fixed by https://github.com/etchteam/recycling-locator/pull/195

The prop might be coming through as a string of "undefined", so trying this additional check.