### PR TITLE
Fix container SVG undefined

### DIFF
--- a/src/components/content/Container/Container.tsx
+++ b/src/components/content/Container/Container.tsx
@@ -34,6 +34,10 @@ function ContainerSvg({
   'body-colour': bodyColour,
   label,
 }: ContainerSvgAttributes) {
+  if (!name || (name as string) === 'undefined') {
+    return null;
+  }
+
   const cssVariables = {
     '--lid-colour': lidColour ?? 'transparent',
     '--body-colour': bodyColour,


### PR DESCRIPTION
Although reduced, we're still getting [the "Unknown variable dynamic import: ./svg/undefined.svg" errors](https://wrap.sentry.io/issues/5542616257/tags/?alert_rule_id=15082034&alert_type=issue&notification_uuid=a1b16f00-d162-4e31-9166-826e829cdea1&project=4506864957194240&referrer=slack)

Based on the tag, they all seem to be from the container SVG now, so I've applied the same fix to this component as was given to the icon component.

![Screenshot 2024-07-12 at 13 53 42](https://github.com/user-attachments/assets/a40b6690-1b68-48c4-a0cd-cbf3abeaa2de)
