### PR TITLE
Fix search bar sitting on top of the header

### DIFF
--- a/src/components/composition/Layout/Layout.css
+++ b/src/components/composition/Layout/Layout.css
@@ -65,7 +65,7 @@ locator-layout {
     grid-area: header;
     position: sticky;
     top: 0;
-    z-index: var(--layer-two);
+    z-index: var(--layer-three);
   }
 
   &::part(main) {

--- a/src/styles/tokens/layer.css
+++ b/src/styles/tokens/layer.css
@@ -1,4 +1,5 @@
 :host {
   --layer-one: 1;
   --layer-two: 2;
+  --layer-three: 3;
 }


### PR DESCRIPTION
The layout has 3 slots: header, main and aside. The search bar is a sticky element that sits inside of main, the tab nav also works this way.

The problem with it being inside main is that when the tip in the aside is tall enough to fill up the screen it pushes main out of view, so the search bar stops scrolling at the bottom of the container and has to move up off the screen with it.

This "fix" layers the header on top of the search bar so the search bar will still scroll off the screen in some scenarios, but it won't sit on top of the header whilst it's doing so which stops it looking broken.

I think this is a viable fix because there are limited scenarios where the main would run out of space – only on mobile when the tip is taller than usual so it fills the screen. Users have to scroll right to the bottom and can see the search moving out of view as they scroll so it should be intuitive to scroll up to reveal it again.

I have played with an extra "context" slot that sits below the header, I think that would be the solution if this fix does cause issues in the future, but I struggled to get the context area scrolling correctly and found it'd be quite a big refactor to get it working so I'm happy with the easy fix for now.