### PR TITLE
fix: allow alternative cases in material search input

### DIFF
--- a/src/components/control/MaterialSearchInput/MaterialSearchInput.tsx
+++ b/src/components/control/MaterialSearchInput/MaterialSearchInput.tsx
@@ -118,7 +118,7 @@ export default class MaterialSearchInput extends Component<MaterialSearchInputPr
 
     const isRealMaterial = matchingMaterialNames?.length > 0;
 
-    // Allow for the input being a real material but the query case not matching the suggestion
+    // Update the query value when it matches a real material but the capitalisation is different
     if (isRealMaterial && !matchingMaterialNames.includes(query)) {
       this.inputRef.current.value = matchingMaterialNames[0];
     }

--- a/src/components/control/MaterialSearchInput/MaterialSearchInput.tsx
+++ b/src/components/control/MaterialSearchInput/MaterialSearchInput.tsx
@@ -107,10 +107,21 @@ export default class MaterialSearchInput extends Component<MaterialSearchInputPr
 
   handleButtonClick = (event: Event) => {
     const query = this.inputRef.current.value;
-    const isRealMaterial =
-      this.materialSuggestions.value?.some?.(
-        (material) => material.name === query,
-      ) ?? [];
+
+    const matchingMaterialNames =
+      this.materialSuggestions.value
+        ?.filter?.(
+          (material) =>
+            material.name.toLocaleLowerCase() === query.toLocaleLowerCase(),
+        )
+        .map((material) => material.name) ?? [];
+
+    const isRealMaterial = matchingMaterialNames?.length > 0;
+
+    // Allow for the input being a real material but the query case not matching the suggestion
+    if (isRealMaterial && !matchingMaterialNames.includes(query)) {
+      this.inputRef.current.value = matchingMaterialNames[0];
+    }
 
     if (!isRealMaterial && query) {
       event.preventDefault();


### PR DESCRIPTION
Small change to the MaterialSearchInput component to ignore case when checking if the material is real.

It now does a case insensitive comparison between the queried material and the material suggestions from the API. If a matching material is found but the case doesn't match, the query value is updated to have the 'correct' capitalisation.