### PR TITLE
docs: add UAT reverse proxy instructions to contributing docs

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -4,7 +4,7 @@ Guidelines for contributions to the Recycling Locator codebase.
 
 ## Get started
 
-Before starting, you will need access to [recycle locator proxy](https://github.com/etchteam/recycle-locator) and have it running locally.
+Before starting, you will need access to [recycle locator proxy](https://github.com/etchteam/recycle-locator) and have it running locally. Alternatively, you can use the UAT proxy.
 
 Make sure you're using the right node version
 
@@ -35,6 +35,19 @@ For component documentation, start storybook on on [http://localhost:6006/](http
 ```bash
 npm run storybook
 ```
+
+If using the UAT recycle locator proxy, you will need to set up a local reverse proxy to a domain that has been whitelisted for CORS.
+
+Download [Caddy](https://caddyserver.com/), then execute the downloaded file and start up the reverse proxy (change the folder and caddy file name in the instructions below if needed)
+
+```bash
+cd ~/Downloads
+chmod +x caddy_darwin_arm64
+./caddy_darwin_arm64
+./caddy_darwin_arm64 reverse-proxy --to :3020 --from rl.localhost
+```
+
+Navigate to [rl.localhost](rl.localhost) in the browser
 
 ## Folder structure
 


### PR DESCRIPTION
Add instructions to the contributing docs on how to use Caddy to set up a reverse proxy to be able to use the recycle locator proxy UAT instead of running it locally.