### PR TITLE
Fix map button out of position

### DIFF
--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -10,6 +10,7 @@ article {
   font-size: var(--diamond-font-size-base);
   overflow-y: auto;
   position: relative;
+  transform: scale(1);
 }
 
 .recycling-locator-variant-widget {


### PR DESCRIPTION
The map button was attaching itself to the browser viewport instead of the locator widget.

<img width="400" alt="Screenshot 2024-10-02 at 17 08 14" src="https://github.com/user-attachments/assets/38bf9c8e-23f7-4af8-8460-ce4cded8b298">

This adds a dummy transform to create a new [containing block](https://developer.mozilla.org/en-US/docs/Web/CSS/position#fixed_positioning) so that the fixed element is forced inside.

Regarding the actual issue, I'm not exactly sure why this seemingly randomly started happening, my guess is a browser update related to shadow DOM?

