### PR TITLE
Analytics tweaks

### DIFF
--- a/src/lib/AppState.tsx
+++ b/src/lib/AppState.tsx
@@ -16,7 +16,8 @@ export const AppState = createContext<AppStateContext>(null);
 export function createAppState(
   attributes: RecyclingLocatorAttributes,
 ): AppStateContext {
-  const sessionId = (window?.crypto?.randomUUID?.() ??
+  const sessionId = (window?.wrapAnalyticsId ??
+    window?.crypto?.randomUUID?.() ??
     uniqueId('session')) as unknown as string;
 
   return {

--- a/src/lib/AppState.tsx
+++ b/src/lib/AppState.tsx
@@ -1,4 +1,4 @@
-import uniqueId from 'lodash';
+import uniqueId from 'lodash/uniqueId';
 import { createContext } from 'preact';
 import { useContext } from 'preact/hooks';
 

--- a/src/lib/useAnalytics.ts
+++ b/src/lib/useAnalytics.ts
@@ -54,13 +54,15 @@ export default function useAnalytics() {
   const { locale, sessionId } = useAppState();
   const location = useLocation();
 
+  const path = typeof window !== 'undefined' ? window?.location?.pathname : '/';
+
   function createEvent(event: Partial<AnalyticsEvent>): AnalyticsEvent {
     return {
       ...event,
       dp: `${location.pathname}${location.search}${location.hash}`,
       cid: sessionId,
       ul: locale === 'cy' ? 'cy-GB' : 'en-GB',
-      dh: config.hostname,
+      dh: `${config.hostname}${path}`,
       vp: `${window.innerWidth}x${window.innerHeight}`,
     } as AnalyticsEvent;
   }

--- a/src/types/window.d.ts
+++ b/src/types/window.d.ts
@@ -1,0 +1,7 @@
+declare global {
+  export interface Window {
+    wrapAnalyticsId?: string;
+  }
+}
+
+export {};


### PR DESCRIPTION
Allows WRAP to override the session ID so that they can link embedded sessions with recycle now/wales recycles sessions.

Also captures the embedding path, for even more analytics power.