### PR TITLE
Add homepage promo tip

### DIFF
--- a/src/components/canvas/Tip/Tip.css
+++ b/src/components/canvas/Tip/Tip.css
@@ -33,6 +33,16 @@ locator-tip {
     }
   }
 
+  &[type='promo'] {
+    --diamond-theme-background: var(--color-green);
+    --diamond-theme-color: var(--color-body);
+    --diamond-theme-heading-color: var(--color-body);
+
+    img {
+      width: 100%;
+    }
+  }
+
   &[text-align='center'] {
     text-align: center;
   }

--- a/src/components/canvas/Tip/Tip.tsx
+++ b/src/components/canvas/Tip/Tip.tsx
@@ -1,7 +1,7 @@
 import { CustomElement } from '@/types/customElement';
 
 export interface TipAttributes {
-  type?: 'image';
+  type?: 'image' | 'promo';
   wrap?: 'wrap';
   'text-align'?: 'center';
 }

--- a/src/components/template/TipContent/TipContent.tsx
+++ b/src/components/template/TipContent/TipContent.tsx
@@ -29,9 +29,11 @@ export default function TipContent({
       {showImage && (
         <img className="diamond-spacing-bottom-sm" src={tipImgSrc} alt="" />
       )}
-      <p className="diamond-text-weight-bold">{tip.subtitle}</p>
+      {tip.subtitle && (
+        <p className="diamond-text-weight-bold">{tip.subtitle}</p>
+      )}
       <h2>{tip.title}</h2>
-      <p>{tip.content}</p>
+      {tip.content && <p>{tip.content}</p>}
       {tip.cta && tip.ctaLink && (
         <diamond-button width={ctaWidth} className="diamond-spacing-top-md">
           <a href={tip.ctaLink} target="_blank" rel="noopener noreferrer">

--- a/src/lib/LocatorApi.ts
+++ b/src/lib/LocatorApi.ts
@@ -13,7 +13,8 @@ export default class LocatorApi {
     url: string,
     options: LocatorApiRequestOptions,
   ): Promise<T> {
-    const locale = i18n.language === 'en' ? 'en-GB' : i18n.language;
+    const locale =
+      !i18n.language || i18n.language === 'en' ? 'en-GB' : i18n.language;
     const fullUrl = new URL(`${config.locatorApiPath}${url}`);
     fullUrl.searchParams.set('lang', locale);
 

--- a/src/lib/getTip.ts
+++ b/src/lib/getTip.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/browser';
 import random from 'lodash/random';
 
+import i18n from '@/lib/i18n';
 import { RecyclingMeta } from '@/types/locatorApi';
 
 import LocatorApi from './LocatorApi';
@@ -13,6 +14,7 @@ export default function getTip(
   options: {
     path?: string;
     materialId?: string | number;
+    country?: string;
   } = {},
 ): RecyclingMeta {
   const tips = [];
@@ -43,10 +45,19 @@ function handleTipError(error: Error) {
   });
 }
 
+function getTipCountry() {
+  return i18n.language === 'cy' || i18n.language === 'cy-GB'
+    ? 'WALES'
+    : 'ENGLAND';
+}
+
 export async function getTipByPath(path: string) {
   try {
-    const meta = await LocatorApi.get<RecyclingMeta[]>('recycling-meta');
-    return getTip(meta, { path });
+    const tips = await LocatorApi.get<RecyclingMeta[]>(
+      `recycling-meta?categories=HINT&path=${path}&country=${getTipCountry()}`,
+    );
+
+    return tips?.[0] ?? null;
   } catch (error) {
     handleTipError(error);
     return Promise.resolve(null);
@@ -56,7 +67,7 @@ export async function getTipByPath(path: string) {
 export async function getTipByMaterial(materialId: string) {
   try {
     const meta = await LocatorApi.get<RecyclingMeta[]>(
-      'recycling-meta?categories=HINT',
+      `recycling-meta?categories=HINT&country=${getTipCountry()}`,
     );
     return getTip(meta, { materialId });
   } catch (error) {

--- a/src/pages/start.layout.tsx
+++ b/src/pages/start.layout.tsx
@@ -1,6 +1,8 @@
 import { useSignal } from '@preact/signals';
 import { ComponentChildren } from 'preact';
+import { Suspense } from 'react';
 import { useTranslation } from 'react-i18next';
+import { Await, useLoaderData } from 'react-router-dom';
 import '@etchteam/diamond-ui/control/Button/Button';
 import '@etchteam/diamond-ui/canvas/Section/Section';
 import '@etchteam/diamond-ui/composition/Enter/Enter';
@@ -11,10 +13,14 @@ import '@/components/content/Logo/Logo';
 import '@/components/content/Icon/Icon';
 import '@/components/canvas/Tip/Tip';
 import '@/components/composition/Wrap/Wrap';
+
 import Footer from '@/components/content/Footer/Footer';
+import TipContent from '@/components/template/TipContent/TipContent';
 import { useAppState } from '@/lib/AppState';
 import i18n from '@/lib/i18n';
 import useAnalytics from '@/lib/useAnalytics';
+
+import { StartLoaderResponse } from './start.loader';
 
 function About() {
   const { t } = useTranslation();
@@ -59,16 +65,40 @@ function About() {
   );
 }
 
-export function DefaultAside() {
+export function DefaultTip() {
   const { publicPath } = useAppState();
   const generalTipImgSrc = `${publicPath}images/general-tip.svg`;
 
   return (
-    <locator-tip slot="layout-aside" type="image">
+    <locator-tip type="image">
       <locator-wrap>
         <img src={generalTipImgSrc} alt="" />
       </locator-wrap>
     </locator-tip>
+  );
+}
+
+export function DefaultAside() {
+  const { tip: tipPromise } = useLoaderData() as StartLoaderResponse;
+
+  return (
+    <div slot="layout-aside" className="display-contents">
+      <Suspense fallback={<DefaultTip />}>
+        <Await resolve={tipPromise}>
+          {(tip) =>
+            tip ? (
+              <locator-tip slot="layout-aside" type="promo" text-align="center">
+                <locator-wrap>
+                  <TipContent tip={tip} />
+                </locator-wrap>
+              </locator-tip>
+            ) : (
+              <DefaultTip />
+            )
+          }
+        </Await>
+      </Suspense>
+    </div>
   );
 }
 

--- a/src/pages/start.loader.ts
+++ b/src/pages/start.loader.ts
@@ -1,0 +1,13 @@
+import { defer } from 'react-router-dom';
+
+import { getTipByPath } from '@/lib/getTip';
+import { RecyclingMeta } from '@/types/locatorApi';
+
+export interface StartLoaderResponse {
+  tip?: Promise<RecyclingMeta>;
+}
+
+export default function startLoader() {
+  const tip = getTipByPath('/');
+  return defer({ tip });
+}

--- a/src/pages/start.page.tsx
+++ b/src/pages/start.page.tsx
@@ -5,6 +5,7 @@ import '@etchteam/diamond-ui/canvas/Section/Section';
 
 import '@/components/composition/Wrap/Wrap';
 import '@/components/control/LocationInput/LocationInput';
+
 import tArray from '@/lib/tArray';
 import StartLayout from '@/pages/start.layout';
 

--- a/src/pages/start.routes.tsx
+++ b/src/pages/start.routes.tsx
@@ -7,6 +7,7 @@ import startAction, {
   homeRecyclingStartAction,
   materialStartAction,
 } from './start.action';
+import startLoader from './start.loader';
 import StartPage from './start.page';
 
 const routes: RouteObject[] = [
@@ -14,18 +15,21 @@ const routes: RouteObject[] = [
     path: '/',
     element: <StartPage />,
     action: startAction,
+    loader: startLoader,
     errorElement: <NotFoundPage />,
   },
   {
     path: '/home-recycling',
     element: <HomeRecyclingStartPage />,
     action: homeRecyclingStartAction,
+    loader: startLoader,
     errorElement: <NotFoundPage />,
   },
   {
     path: '/material',
     element: <MaterialStartPage />,
     action: materialStartAction,
+    loader: startLoader,
     errorElement: <NotFoundPage />,
   },
 ];

--- a/src/types/locatorApi.ts
+++ b/src/types/locatorApi.ts
@@ -138,8 +138,8 @@ export interface RecyclingMeta {
   id: number;
   category: 'HINT' | 'QUESTION';
   title: string;
-  subtitle: string;
-  content: string;
+  subtitle?: string;
+  content?: string;
   materials?: number[];
   path?: string;
   image?: string;


### PR DESCRIPTION
Adds the start page promo tip, it's got a different background and a full width image. It'll fallback to the standard image if no tip with a path of "/" is found.

<img width="1030" alt="Screenshot 2025-03-13 at 19 52 03" src="https://github.com/user-attachments/assets/675764aa-e194-4f59-a9b8-94a5a816855c" />

This also makes proper use of the path filter on the proxy and adds support for the country filter based on the i18n.language.

