### PR TITLE
Fix releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ permissions:
   contents: read
 jobs:
   publish:
-    name: Publish
+    name: 🚀 Publish
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -18,19 +18,16 @@ jobs:
       pull-requests: write
       id-token: write
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           persist-credentials: false
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
           cache: npm
-      - name: Install dependencies
-        run: npm ci
-      - name: Get package version
+      - run: npm ci
+      - name: Get the package version for this release (previous version + 1)
         id: package-version
         run: |
           npm run release -- --ci false --dryRun | tee /dev/tty | grep -i "Published release" > .semver-output
@@ -38,8 +35,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-      - name: Build
-        run: npm run build
+      - run: npm run build
         env:
           SENTRY_ORG: 'wrap'
           SENTRY_PROJECT: 'recycling-locator'
@@ -50,8 +46,7 @@ jobs:
           VITE_PUBLIC_PATH: https://cdn.jsdelivr.net/npm/@etchteam/recycling-locator@${{ steps.package-version.outputs.current-version }}/dist/
           VITE_PACKAGE_VERSION: ${{ steps.package-version.outputs.current-version }}
           VITE_ENABLE_ANALYTICS: 'true'
-      - name: Publish
-        run: npm run release
+      - run: npm run release
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,7 @@ jobs:
           node-version-file: .nvmrc
           cache: npm
       - run: npm ci
+      - run: npm audit signatures
       - name: Get the package version for this release (previous version + 1)
         id: package-version
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,6 @@ jobs:
       issues: write
       pull-requests: write
       id-token: write
-    if: "!contains(toJSON(github.event.commits.*.message), '[skip ci]')"
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,9 +30,7 @@ jobs:
       - run: npm audit signatures
       - name: Get the package version for this release (previous version + 1)
         id: package-version
-        run: |
-          npm run release -- --ci false --dryRun | tee /dev/tty | grep -i "Published release" > .semver-output
-          echo "current-version=$([[ $(cat .semver-output) =~ .*([[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+) ]] && echo "${BASH_REMATCH[1]}")" >> "$GITHUB_OUTPUT"
+        run: ./scripts/get-next-version.sh
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.npmrc
+++ b/.npmrc
@@ -2,3 +2,4 @@
 fund=false
 audit=false
 preferOffline=true
+provenance=true

--- a/scripts/get-next-version.sh
+++ b/scripts/get-next-version.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+# Github actions don't expose /dev/tty, but tty should return a usable device
+tty=$(tty)
+
+# Run the release in dry run so that we can grab the version that this action will publish
+npm run release -- --ci false --dryRun | tee "$tty" | grep -i "Published release" > .semver-output
+
+# Push this version to the output
+echo "current-version=$([[ $(cat .semver-output) =~ .*([[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+) ]] && echo "${BASH_REMATCH[1]}")" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Moves the next version grabbing to a shell script and calls tty to get a usable device, which should fix the release.

Additionally adds provenance publishing to trigger a new release, and tidies up the action a little.