### PR TITLE
Get tip by path fallback option

### DIFF
--- a/src/lib/getTip.ts
+++ b/src/lib/getTip.ts
@@ -51,13 +51,29 @@ function getTipCountry() {
     : 'ENGLAND';
 }
 
-export async function getTipByPath(path: string) {
+/**
+ * Get a tip for a given path name
+ *
+ * @param path - The path to get the tip for (a path can be set in the admin)
+ * @param fallback – whether to fallback to a random tip if no tip is found for the path
+ */
+export async function getTipByPath(
+  path: string,
+  { fallback }: { fallback?: boolean } = { fallback: true },
+) {
   try {
-    const tips = await LocatorApi.get<RecyclingMeta[]>(
-      `recycling-meta?categories=HINT&path=${path}&country=${getTipCountry()}`,
-    );
+    if (fallback) {
+      const meta = await LocatorApi.get<RecyclingMeta[]>(
+        `recycling-meta?categories=HINT&country=${getTipCountry()}`,
+      );
+      return getTip(meta, { path });
+    } else {
+      const tips = await LocatorApi.get<RecyclingMeta[]>(
+        `recycling-meta?categories=HINT&path=${path}&country=${getTipCountry()}`,
+      );
 
-    return tips?.[0] ?? null;
+      return tips?.[0] ?? null;
+    }
   } catch (error) {
     handleTipError(error);
     return Promise.resolve(null);

--- a/src/pages/start.loader.ts
+++ b/src/pages/start.loader.ts
@@ -8,6 +8,6 @@ export interface StartLoaderResponse {
 }
 
 export default function startLoader() {
-  const tip = getTipByPath('/');
+  const tip = getTipByPath('/', { fallback: false });
   return defer({ tip });
 }


### PR DESCRIPTION
Recent changes to the getTipByPath functionality would alter its behaviour by not falling back to a random tip if the tip for the path was not found. A fallback option which defaults to true has been added to avoid this breaking change.

We don't want to fallback to a random tip for the start page – it has a default fallback image already, so the fallback option for this route has been set to false.