### PR TITLE
Fix flash of default tip

### DIFF
--- a/src/pages/start.layout.tsx
+++ b/src/pages/start.layout.tsx
@@ -78,12 +78,20 @@ export function DefaultTip() {
   );
 }
 
+export function LoadingTip() {
+  return (
+    <locator-tip>
+      <locator-wrap></locator-wrap>
+    </locator-tip>
+  );
+}
+
 export function DefaultAside() {
   const { tip: tipPromise } = useLoaderData() as StartLoaderResponse;
 
   return (
     <div slot="layout-aside" className="display-contents">
-      <Suspense fallback={<DefaultTip />}>
+      <Suspense fallback={<LoadingTip />}>
         <Await resolve={tipPromise}>
           {(tip) =>
             tip ? (


### PR DESCRIPTION
The default tip image had enough time to display when the recycling meta endpoint took a while to respond.

This changes it so an empty default green section displays first, followed by either:

- the start route tip if one is found
- the default tip if no tip is found
 


https://github.com/user-attachments/assets/1abec1e8-7a08-4d84-802e-54279d7f555e



