### PR TITLE
Fix getTipCountry locale detection

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,5 +8,8 @@
     "connectionId": "Etch",
     "projectKey": "etchteam_recycling-locator-widget"
   },
-  "typescript.tsdk": "node_modules/typescript/lib"
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "i18n-ally.localesPaths": [
+    "public/translations"
+  ]
 }

--- a/src/lib/getTip.ts
+++ b/src/lib/getTip.ts
@@ -46,13 +46,6 @@ function handleTipError(error: Error) {
 }
 
 async function getTipCountry(): Promise<'ENGLAND' | 'WALES'> {
-  const isOnWalesRecycles = window.location.host.includes('walesrecycles');
-
-  if (i18n.language === 'en' && isOnWalesRecycles) {
-    // Use English Welsh for Wales Recycles
-    await i18n.changeLanguage('cy-GB');
-  }
-
   return i18n.language === 'cy' || i18n.language === 'cy-GB'
     ? 'WALES'
     : 'ENGLAND';

--- a/src/lib/getTip.ts
+++ b/src/lib/getTip.ts
@@ -46,9 +46,13 @@ function handleTipError(error: Error) {
 }
 
 async function getTipCountry(): Promise<'ENGLAND' | 'WALES'> {
-  return i18n.language === 'cy' || i18n.language === 'cy-GB'
-    ? 'WALES'
-    : 'ENGLAND';
+  return new Promise((resolve) => {
+    i18n.on('initialized', () => {
+      const isWelshLocale = i18n.language === 'cy' || i18n.language === 'cy-GB';
+      const isWalesRecycles = window.location.host.includes('walesrecycles');
+      resolve(isWelshLocale || isWalesRecycles ? 'WALES' : 'ENGLAND');
+    });
+  });
 }
 
 /**

--- a/src/pages/[postcode]/postcode.page.tsx
+++ b/src/pages/[postcode]/postcode.page.tsx
@@ -242,21 +242,22 @@ export default function PostcodePage() {
                 </Suspense>
               </dl>
             </nav>
-            {locale === 'en' && (
-              <locator-rescue-me-recycle-promo>
-                <Link
-                  to={`/${postcode}/rescue-me-recycle`}
-                  unstable_viewTransition
-                >
-                  <img
-                    src={`${publicPath}images/rescue-me-recycle.webp`}
-                    alt={t('rescueMeRecycle.imgAlt')}
-                    width="254"
-                    height="120"
-                  />
-                </Link>
-              </locator-rescue-me-recycle-promo>
-            )}
+            {locale === 'en' &&
+              !window.location.host.includes('walesrecycles') && (
+                <locator-rescue-me-recycle-promo>
+                  <Link
+                    to={`/${postcode}/rescue-me-recycle`}
+                    unstable_viewTransition
+                  >
+                    <img
+                      src={`${publicPath}images/rescue-me-recycle.webp`}
+                      alt={t('rescueMeRecycle.imgAlt')}
+                      width="254"
+                      height="120"
+                    />
+                  </Link>
+                </locator-rescue-me-recycle-promo>
+              )}
           </diamond-enter>
         </diamond-section>
       </locator-wrap>


### PR DESCRIPTION
i18n doesn't have time to initialise before the start page loader runs, which causes ENGLAND to return as the country. This fix waits for i18n to be initialised before setting the country.

The change language call based on the user being on wales recycles has been removed. I'm not sure we want this to happen, and if we did, it probably shouldn't happen here. For now, I've added an extra check for the static promo only.