### PR TITLE
Fix: WRAP-1698: Fix tips not loading

### DIFF
--- a/src/lib/getTip.ts
+++ b/src/lib/getTip.ts
@@ -6,6 +6,9 @@ import { RecyclingMeta } from '@/types/locatorApi';
 
 import LocatorApi from './LocatorApi';
 
+type Country = 'ENGLAND' | 'WALES';
+let tipCountryPromise: Promise<Country>;
+
 /**
  * Get a tip for a material or path, falling back to a random generic tip
  */
@@ -45,22 +48,22 @@ function handleTipError(error: Error) {
   });
 }
 
-async function getTipCountry(): Promise<'ENGLAND' | 'WALES'> {
-  const determineCountry = (): 'ENGLAND' | 'WALES' => {
-    const isWelshLocale = i18n.language === 'cy' || i18n.language === 'cy-GB';
-    const isWalesRecycles = window.location.host.includes('walesrecycles');
-    return isWelshLocale || isWalesRecycles ? 'WALES' : 'ENGLAND';
-  };
-
-  if (!i18n.isInitialized) {
-    return new Promise((resolve) => {
+/**
+ * Get the country for the tip
+ * Saves the promise to avoid repeated checks
+ */
+async function getTipCountry(): Promise<Country> {
+  if (tipCountryPromise === undefined) {
+    tipCountryPromise = new Promise((resolve) => {
       i18n.on('initialized', () => {
-        resolve(determineCountry());
+        const isWelshLocale =
+          i18n.language === 'cy' || i18n.language === 'cy-GB';
+        const isWalesRecycles = window.location.host.includes('walesrecycles');
+        resolve(isWelshLocale || isWalesRecycles ? 'WALES' : 'ENGLAND');
       });
     });
   }
-
-  return determineCountry();
+  return tipCountryPromise;
 }
 
 /**

--- a/src/lib/getTip.ts
+++ b/src/lib/getTip.ts
@@ -94,8 +94,9 @@ export async function getTipByPath(
 
 export async function getTipByMaterial(materialId: string) {
   try {
+    const country = await getTipCountry();
     const meta = await LocatorApi.get<RecyclingMeta[]>(
-      `recycling-meta?categories=HINT&country=${getTipCountry()}`,
+      `recycling-meta?categories=HINT&country=${country}`,
     );
     return getTip(meta, { materialId });
   } catch (error) {

--- a/src/lib/getTip.ts
+++ b/src/lib/getTip.ts
@@ -46,13 +46,21 @@ function handleTipError(error: Error) {
 }
 
 async function getTipCountry(): Promise<'ENGLAND' | 'WALES'> {
-  return new Promise((resolve) => {
-    i18n.on('initialized', () => {
-      const isWelshLocale = i18n.language === 'cy' || i18n.language === 'cy-GB';
-      const isWalesRecycles = window.location.host.includes('walesrecycles');
-      resolve(isWelshLocale || isWalesRecycles ? 'WALES' : 'ENGLAND');
+  const determineCountry = (): 'ENGLAND' | 'WALES' => {
+    const isWelshLocale = i18n.language === 'cy' || i18n.language === 'cy-GB';
+    const isWalesRecycles = window.location.host.includes('walesrecycles');
+    return isWelshLocale || isWalesRecycles ? 'WALES' : 'ENGLAND';
+  };
+
+  if (!i18n.isInitialized) {
+    return new Promise((resolve) => {
+      i18n.on('initialized', () => {
+        resolve(determineCountry());
+      });
     });
-  });
+  }
+
+  return determineCountry();
 }
 
 /**


### PR DESCRIPTION
Closes both [WRAP-1698](https://linear.app/etch/issue/WRAP-1698/start-page-tip-is-blank-when-clicking-change-postcode) & [WRAP-1709](https://linear.app/etch/issue/WRAP-1709/item-specific-tips-not-loading)

Issues fixed:
- WRAP-1698: Tip wasn't appearing when returning to the start page from other pages, this was because the getTipCountry call only resolved when i18n.on runs, which only runs on the first initialization
- WRAP-1709: Tips for materials weren't loading, this was fixed by the above and updating getTipCountry call to await

Also addressed:
- Seems unnecessary to re-check the country everytime, if the web address changes then the whole locator would be reload anyway, so added a saved copy of the country
- ^ If there is an issue with this approach, then !(i18n.initialised) can be used to ensure local is always resolved after first load