### PR TITLE
Force left align by default

### DIFF
--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -18,6 +18,7 @@ article {
   border-radius: var(--container-border-radius);
   box-sizing: content-box;
   height: var(--container-height);
+  text-align: left;
 }
 
 .recycling-locator-variant-standalone {


### PR DESCRIPTION
Set left align by default to prevent page styles centering all our copy like this:

![image](https://github.com/user-attachments/assets/86c3732b-4275-4983-8b60-14d1e23b6d3b)

Found while investigating WRAP-1697, closes WRAP-1710.
