### PR TITLE
fix: handle missing materials

### DIFF
--- a/src/pages/[postcode]/material/material.loader.ts
+++ b/src/pages/[postcode]/material/material.loader.ts
@@ -43,10 +43,10 @@ export default async function materialLoader({
   );
 
   const material = LocatorApi.getInstance().get<Material>(
-    `materials/${url.searchParams.get('materials')}`,
+    `materials/${url.searchParams.get('materials') ?? ''}`,
   );
 
-  const tip = getTipByMaterial(url.searchParams.get('materials'));
+  const tip = getTipByMaterial(url.searchParams.get('materials') ?? '');
 
   return {
     localAuthority,


### PR DESCRIPTION
`url.searchParams.get` returns `string | null`, which was causing the URL to become `/materials/null` when `materials` was not populated, leading to a 404 error being thrown.

I'm not sure if this issue was always present and has just been highlighted by the axios rollout, or if this has been caused by the axiois rollout. `fetch` seems to also 404 with the URL, so I suspect the error was just flying under the radar previously, although it seems odd that it wasn't raised.