### PR TITLE
Welsh translations sign-up form mop up

### DIFF
--- a/public/translations/cy.json
+++ b/public/translations/cy.json
@@ -630,6 +630,7 @@
       "success": {
         "title": "Diolch am gofrestru!",
         "description": "Byddwn yn rhoi gwybod i chi pan fydd lleoliadau ail-lenwi ar gael yn eich ardal.",
+        "already": "Rydych chi eisoes wedi tanysgrifio, mae eich proffil wedi'i ddiweddaru. Diolch!",
         "confirmation": "Gwiriwch eich e-bost a chliciwch ar y ddolen i gadarnhau eich tanysgrifiad."
       },
       "form": {

--- a/public/translations/cy.json
+++ b/public/translations/cy.json
@@ -623,6 +623,7 @@
       "title": "Byddwch y cyntaf i wybod pan fydd lleoliadau ail-lenwi yn cyrraedd",
       "description": "Cyn bo hir byddwch yn gallu defnyddio'r Lleolydd i ddod o hyd i siopau ail-lenwi yn eich ardal.",
       "button": "Cofrestru",
+      "loading": "Wrthi'n cofrestru...",
       "error": "Mae gwall wedi digwydd, rhowch gynnig ar gyflwyno eto.",
       "business": "neu <a>Cysylltwch â ni ynghylch eich busnes ail-lenwi</a>",
       "businessLink": "https://www.wrap.ngo/take-action/recycle-now/recycling-locator-tool",

--- a/public/translations/en.json
+++ b/public/translations/en.json
@@ -644,6 +644,7 @@
       "success": {
         "title": "Thank you for signing up!",
         "description": "We'll let you know when refill locations are available in your area.",
+        "already": "You're already subscribed, your profile has been updated. Thank you!",
         "confirmation": "Please check your email and click the link to confirm your subscription."
       },
       "form": {

--- a/public/translations/en.json
+++ b/public/translations/en.json
@@ -637,6 +637,7 @@
       "title": "Be the first to know when refill locations arrive",
       "description": "You'll soon be able to use the Locator to find refill stores in your area.",
       "button": "Sign up",
+      "loading": "Signing up...",
       "error": "An error has occured, please try submitting again.",
       "business": "or <a>Get in touch about your refill business</a>",
       "businessLink": "https://www.wrap.ngo/take-action/recycle-now/recycling-locator-tool",

--- a/src/pages/refill/sign-up.page.tsx
+++ b/src/pages/refill/sign-up.page.tsx
@@ -259,7 +259,7 @@ export default function SignUpPage() {
               <button type="submit" disabled={isSubmitting || !!isSubmitted}>
                 {isSubmitting
                   ? t('refill.sign-up.loading')
-                  : t('refill.sign-up-button')}
+                  : t('refill.sign-up.button')}
               </button>
             </diamond-button>
           </Form>

--- a/src/pages/refill/sign-up.page.tsx
+++ b/src/pages/refill/sign-up.page.tsx
@@ -255,7 +255,9 @@ export default function SignUpPage() {
               className="diamond-spacing-bottom-md"
             >
               <button type="submit" disabled={isSubmitting || !!isSubmitted}>
-                {isSubmitting ? 'Signing up...' : 'Sign up'}
+                {isSubmitting
+                  ? t('refill.sign-up.loading')
+                  : t('refill.sign-up-button')}
               </button>
             </diamond-button>
           </Form>

--- a/src/pages/refill/sign-up.page.tsx
+++ b/src/pages/refill/sign-up.page.tsx
@@ -219,16 +219,18 @@ export default function SignUpPage() {
                       setErrors((prev) => ({ ...prev, gdpr: false }))
                     }
                   />
-                  <Trans
-                    i18nKey={'refill.sign-up.form.gdpr.label'}
-                    components={{
-                      a: (
-                        <Link
-                          to={t('refill.sign-up.form.gdpr.link') as string}
-                        />
-                      ),
-                    }}
-                  />
+                  <span>
+                    <Trans
+                      i18nKey={'refill.sign-up.form.gdpr.label'}
+                      components={{
+                        a: (
+                          <Link
+                            to={t('refill.sign-up.form.gdpr.link') as string}
+                          />
+                        ),
+                      }}
+                    />
+                  </span>
                 </label>
               </diamond-radio-checkbox>
               {errors.gdpr && (

--- a/src/pages/refill/sign-up.page.tsx
+++ b/src/pages/refill/sign-up.page.tsx
@@ -18,7 +18,7 @@ export default function SignUpPage() {
 
   const [error, setError] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [isSubmitted, setIsSubmitted] = useState('');
+  const [isSuccessful, setIsSuccessful] = useState(false);
 
   const action =
     'https://wrap.us1.list-manage.com/subscribe/post-json?u=65343110dd35be920e719fccd&amp;id=3d85122919&amp;f_id=00ffd3e0f0';
@@ -67,8 +67,8 @@ export default function SignUpPage() {
       const result = await response.json();
 
       if (result.result === 'success') {
-        // Display already subscribed message from MailChimp if user tries to sign up again
-        setIsSubmitted(result.msg || t('refill.sign-up.success.confirmation'));
+        console.log('Success:', result.msg);
+        setIsSuccessful(true);
         window.scrollTo({ top: 0, behavior: 'smooth' });
       } else {
         throw new Error(result.msg || t('refill.sign-up.error'));
@@ -95,18 +95,18 @@ export default function SignUpPage() {
   return (
     <diamond-section padding="lg">
       <div aria-live="polite" role="status" aria-atomic="true">
-        {isSubmitted && (
-          <>
+        {isSuccessful && (
+          <div className="diamond-spacing-bottom-md">
             <h2>{t('refill.sign-up.success.title')}</h2>
-            <p className="text-color-positive diamond-text-size-sm">
-              {isSubmitted}
+            <p className="text-color-positive">
+              {t('refill.sign-up.success.description')}
             </p>
-            <p>{t('refill.sign-up.success.description')}</p>
-          </>
+            <p>{t('refill.sign-up.success.confirmation')}</p>
+          </div>
         )}
       </div>
 
-      {!isSubmitted && (
+      {!isSuccessful && (
         <>
           <h2>{t('refill.sign-up.title')}</h2>
           <p>{t('refill.sign-up.description')}</p>
@@ -128,7 +128,7 @@ export default function SignUpPage() {
                   name="MMERGE6"
                   type="text"
                   required
-                  disabled={isSubmitting || !!isSubmitted}
+                  disabled={isSubmitting || isSuccessful}
                   onChange={() =>
                     setErrors((prev) => ({ ...prev, name: false }))
                   }
@@ -158,7 +158,7 @@ export default function SignUpPage() {
                     t('refill.sign-up.form.email.placeholder') as string
                   }
                   required
-                  disabled={isSubmitting || !!isSubmitted}
+                  disabled={isSubmitting || isSuccessful}
                   onChange={() =>
                     setErrors((prev) => ({ ...prev, email: false }))
                   }
@@ -189,7 +189,7 @@ export default function SignUpPage() {
                     t('refill.sign-up.form.postcode.placeholder') as string
                   }
                   required
-                  disabled={isSubmitting || !!isSubmitted}
+                  disabled={isSubmitting || isSuccessful}
                   onChange={() =>
                     setErrors((prev) => ({ ...prev, postcode: false }))
                   }
@@ -214,7 +214,7 @@ export default function SignUpPage() {
                     id="gdpr-input"
                     name="gdpr-input"
                     required
-                    disabled={isSubmitting || !!isSubmitted}
+                    disabled={isSubmitting || isSuccessful}
                     onChange={() =>
                       setErrors((prev) => ({ ...prev, gdpr: false }))
                     }
@@ -256,7 +256,7 @@ export default function SignUpPage() {
               width="full-width"
               className="diamond-spacing-bottom-md"
             >
-              <button type="submit" disabled={isSubmitting || !!isSubmitted}>
+              <button type="submit" disabled={isSubmitting || isSuccessful}>
                 {isSubmitting
                   ? t('refill.sign-up.loading')
                   : t('refill.sign-up.button')}


### PR DESCRIPTION
- Fix: Make sure buttons are all translated as expected
- Feat: Detect previously submitted state so message can be translated
- Fix: Only show detailed mailchimp errors for english users - welsh get generic translated please try again message
- Fix: Wrap GDPR label in span to override diamond form label flexbox spacing issue

Extra:
- Feat: Add local storage to retain submitted form state