### PR TITLE
Consolidate refill store details output with first-win logic

### DIFF
--- a/src/components/content/PlaceNotes/PlaceNotes.tsx
+++ b/src/components/content/PlaceNotes/PlaceNotes.tsx
@@ -10,7 +10,7 @@ import Linkify from 'linkify-react';
  *      so the user sees the familiar `///` notation rather than a full URL.
  */
 function formatWhat3WordsDisplay(value: string): string {
-  if (value.includes('https://what3words.com')) {
+  if (value.startsWith('https://what3words.com/')) {
     return value.replace('https://what3words.com/', '///');
   }
   return value;

--- a/src/components/content/PlaceNotes/PlaceNotes.tsx
+++ b/src/components/content/PlaceNotes/PlaceNotes.tsx
@@ -1,0 +1,43 @@
+import Linkify from 'linkify-react';
+
+/**
+ * Linkify calls this for each detected URL or text segment.
+ *
+ * what3words addresses go through a round-trip:
+ *   1. getNotes converts `///word.word.word` → `https://what3words.com/word.word.word`
+ *      so that Linkify recognises them as clickable URLs.
+ *   2. This formatter converts those URLs back to `///word.word.word` for display,
+ *      so the user sees the familiar `///` notation rather than a full URL.
+ */
+function formatWhat3WordsDisplay(value: string): string {
+  if (value.includes('https://what3words.com')) {
+    return value.replace('https://what3words.com/', '///');
+  }
+  return value;
+}
+
+export default function PlaceNotes({ notes }: { readonly notes: string[] }) {
+  if (notes.length === 0) {
+    return null;
+  }
+
+  return (
+    <>
+      {notes.map((note) => (
+        <dd key={note}>
+          <Linkify
+            options={{
+              target: '_blank',
+              rel: 'noopener noreferrer',
+              nl2br: true,
+              defaultProtocol: 'https',
+              format: formatWhat3WordsDisplay,
+            }}
+          >
+            {note}
+          </Linkify>
+        </dd>
+      ))}
+    </>
+  );
+}

--- a/src/lib/details/getNotes.ts
+++ b/src/lib/details/getNotes.ts
@@ -6,13 +6,10 @@ export default function getNotes(location: Location) {
   return location.locations
     .map((loc) => loc.notes?.trim())
     .filter(Boolean)
-    .map((note) => {
-      if (WHAT_THREE_WORDS_REGEX.test(note)) {
-        return note
-          .replace(WHAT_THREE_WORDS_REGEX, 'https://what3words.com/$&')
-          .replace(/\/\/\//g, '');
-      }
-
-      return note;
-    });
+    .map((note) =>
+      note.replaceAll(
+        WHAT_THREE_WORDS_REGEX,
+        (match) => `https://what3words.com/${match.slice(3)}`,
+      ),
+    );
 }

--- a/src/lib/details/getRefillPlaceDetails.ts
+++ b/src/lib/details/getRefillPlaceDetails.ts
@@ -9,54 +9,22 @@ interface RefillPlaceDetails {
   phoneNumber: string | undefined;
   website: { url: string; text: string } | undefined;
   openingHours: OpeningHoursResult;
-  notes: string[];
+  note: string | undefined;
 }
 
-/**
- * Returns details for a refill place location.
- *
- * Refill locations differ from recycling locations in that their sub-locations
- * all represent the same physical shop supplied by the same brand. This means
- * there is only ever one phone number, website, set of opening hours and notes
- * to display — the first available value for each detail type is the canonical
- * one. Recycling locations, by contrast, can be served by completely different
- * companies sharing an address, each with independent contact details.
- *
- * The aggregation logic is intentionally shared with the recycling detail
- * helpers (getPhoneNumbers, getWebsites, getOpeningHours, getNotes) so that
- * cleaning, formatting and normalisation stay consistent. We simply take the
- * first result from each aggregated collection.
- */
 export default function getRefillPlaceDetails(
   location: Location,
 ): RefillPlaceDetails {
-  const phoneNumbers = getPhoneNumbers(location);
-  const websites = getWebsites(location);
-  const notes = getNotes(location);
+  const phoneNumber = getPhoneNumbers(location)[0];
+  const note = getNotes(location)[0];
 
-  // For refill locations all sub-locations share the same brand/shop, so the
-  // first aggregated value for each detail is the only one needed.
-  const phoneNumber = phoneNumbers[0];
-  const firstNote = notes[0];
+  const [url, text] = [...getWebsites(location).entries()][0] ?? [];
+  const website = url ? { url, text } : undefined;
 
-  const firstWebsiteEntry = websites.entries().next().value;
-  const website = firstWebsiteEntry
-    ? { url: firstWebsiteEntry[0], text: firstWebsiteEntry[1] }
-    : undefined;
-
-  // getOpeningHours iterates all sub-locations and the last one wins via Map
-  // overwrite. For refill places this is fine because all sub-locations belong
-  // to the same shop — the first location with opening hours is the authoritative
-  // source, so we pass a synthetic location containing only that sub-location.
   const firstLocWithHours = location.locations.find((loc) => loc.openingHours);
   const openingHours = firstLocWithHours
     ? getOpeningHours({ ...location, locations: [firstLocWithHours] })
     : { today: '', days: [] };
 
-  return {
-    phoneNumber,
-    website,
-    openingHours,
-    notes: firstNote ? [firstNote] : [],
-  };
+  return { phoneNumber, website, openingHours, note };
 }

--- a/src/lib/details/getRefillPlaceDetails.ts
+++ b/src/lib/details/getRefillPlaceDetails.ts
@@ -1,0 +1,62 @@
+import { Location } from '@/types/locatorApi';
+
+import getNotes from './getNotes';
+import getOpeningHours, { type OpeningHoursResult } from './getOpeningHours';
+import getPhoneNumbers from './getPhoneNumbers';
+import getWebsites from './getWebsites';
+
+interface RefillPlaceDetails {
+  phoneNumber: string | undefined;
+  website: { url: string; text: string } | undefined;
+  openingHours: OpeningHoursResult;
+  notes: string[];
+}
+
+/**
+ * Returns details for a refill place location.
+ *
+ * Refill locations differ from recycling locations in that their sub-locations
+ * all represent the same physical shop supplied by the same brand. This means
+ * there is only ever one phone number, website, set of opening hours and notes
+ * to display — the first available value for each detail type is the canonical
+ * one. Recycling locations, by contrast, can be served by completely different
+ * companies sharing an address, each with independent contact details.
+ *
+ * The aggregation logic is intentionally shared with the recycling detail
+ * helpers (getPhoneNumbers, getWebsites, getOpeningHours, getNotes) so that
+ * cleaning, formatting and normalisation stay consistent. We simply take the
+ * first result from each aggregated collection.
+ */
+export default function getRefillPlaceDetails(
+  location: Location,
+): RefillPlaceDetails {
+  const phoneNumbers = getPhoneNumbers(location);
+  const websites = getWebsites(location);
+  const notes = getNotes(location);
+
+  // For refill locations all sub-locations share the same brand/shop, so the
+  // first aggregated value for each detail is the only one needed.
+  const phoneNumber = phoneNumbers[0];
+  const firstNote = notes[0];
+
+  const firstWebsiteEntry = websites.entries().next().value;
+  const website = firstWebsiteEntry
+    ? { url: firstWebsiteEntry[0], text: firstWebsiteEntry[1] }
+    : undefined;
+
+  // getOpeningHours iterates all sub-locations and the last one wins via Map
+  // overwrite. For refill places this is fine because all sub-locations belong
+  // to the same shop — the first location with opening hours is the authoritative
+  // source, so we pass a synthetic location containing only that sub-location.
+  const firstLocWithHours = location.locations.find((loc) => loc.openingHours);
+  const openingHours = firstLocWithHours
+    ? getOpeningHours({ ...location, locations: [firstLocWithHours] })
+    : { today: '', days: [] };
+
+  return {
+    phoneNumber,
+    website,
+    openingHours,
+    notes: firstNote ? [firstNote] : [],
+  };
+}

--- a/src/pages/[postcode]/places/place/details.page.tsx
+++ b/src/pages/[postcode]/places/place/details.page.tsx
@@ -1,9 +1,9 @@
-import Linkify from 'linkify-react';
 import nl2br from 'nl2br';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'wouter-preact';
 
 import OpeningHours from '@/components/content/OpeningHours/OpeningHours';
+import PlaceNotes from '@/components/content/PlaceNotes/PlaceNotes';
 import RateThisInfo from '@/components/control/RateThisInfo/RateThisInfo';
 import { usePlace } from '@/hooks/usePlace';
 import cleanupAddress from '@/lib/cleanupAddress';
@@ -89,27 +89,7 @@ function PlaceDetailsPageContent({
               <dt>
                 <locator-icon icon="docs" /> {t('place.details.notes')}
               </dt>
-              {notes.map((note) => (
-                <dd key={note}>
-                  {
-                    <Linkify
-                      options={{
-                        target: '_blank',
-                        rel: 'noopener noreferrer',
-                        nl2br: true,
-                        defaultProtocol: 'https',
-                        format: (value) => {
-                          return value.includes('https://what3words.com')
-                            ? value.replace('https://what3words.com/', '///')
-                            : value;
-                        },
-                      }}
-                    >
-                      {note}
-                    </Linkify>
-                  }
-                </dd>
-              ))}
+              <PlaceNotes notes={notes} />
             </div>
           )}
         </dl>

--- a/src/pages/[postcode]/refill/places/place/place.page.tsx
+++ b/src/pages/[postcode]/refill/places/place/place.page.tsx
@@ -1,18 +1,15 @@
-import Linkify from 'linkify-react';
 import camelCase from 'lodash/camelCase';
 import { Trans, useTranslation } from 'react-i18next';
 import { Link, useParams } from 'wouter-preact';
 
 import OpeningHours from '@/components/content/OpeningHours/OpeningHours';
+import PlaceNotes from '@/components/content/PlaceNotes/PlaceNotes';
 import RateThisInfo from '@/components/control/RateThisInfo/RateThisInfo';
 import { useAppState } from '@/hooks/AppStateProvider';
 import { usePostcode } from '@/hooks/PostcodeProvider';
 import { useRefillPlace } from '@/hooks/useRefillPlace';
 import cleanupAddress from '@/lib/cleanupAddress';
-import getNotes from '@/lib/details/getNotes';
-import getOpeningHours from '@/lib/details/getOpeningHours';
-import getPhoneNumbers from '@/lib/details/getPhoneNumbers';
-import getWebsites from '@/lib/details/getWebsites';
+import getRefillPlaceDetails from '@/lib/details/getRefillPlaceDetails';
 import getCompanyNames from '@/lib/getCompanyNames';
 import { REFILL_CATEGORIES } from '@/lib/refillCategories';
 import { Location, RefillCategory } from '@/types/locatorApi';
@@ -166,10 +163,8 @@ function RefillPlaceContent({ location }: { readonly location: Location }) {
     throw new Error(location.error);
   }
 
-  const phoneNumbers = getPhoneNumbers(location);
-  const [firstSite] = getWebsites(location).keys();
-  const openingHours = getOpeningHours(location);
-  const notes = getNotes(location);
+  const { phoneNumber, website, openingHours, notes } =
+    getRefillPlaceDetails(location);
   const address = cleanupAddress(location.address);
 
   return (
@@ -177,22 +172,20 @@ function RefillPlaceContent({ location }: { readonly location: Location }) {
       <locator-bordered-list size="sm" className="evg-spacing-bottom-md">
         <dl>
           <OpeningHours openingHours={openingHours} />
-          {phoneNumbers.length > 0 && (
+          {phoneNumber && (
             <div>
               <dt>{t('place.details.phone')}</dt>
-              {phoneNumbers.map((num) => (
-                <dd key={num}>
-                  <a href={`tel:${num}`}>{num}</a>
-                </dd>
-              ))}
+              <dd>
+                <a href={`tel:${phoneNumber}`}>{phoneNumber}</a>
+              </dd>
             </div>
           )}
-          {firstSite && (
+          {website && (
             <div>
               <dt>{t('place.details.website')}</dt>
               <dd>
                 <a
-                  href={`${firstSite}?utm_source=wrap-recycling-locator`}
+                  href={`${website.url}?utm_source=wrap-recycling-locator`}
                   target="_blank"
                   rel="noopener noreferrer"
                 >
@@ -226,27 +219,7 @@ function RefillPlaceContent({ location }: { readonly location: Location }) {
           {notes.length > 0 && (
             <div>
               <dt>{t('place.details.notes')}</dt>
-              {notes.map((note) => (
-                <dd key={note}>
-                  {
-                    <Linkify
-                      options={{
-                        target: '_blank',
-                        rel: 'noopener noreferrer',
-                        nl2br: true,
-                        defaultProtocol: 'https',
-                        format: (value) => {
-                          return value.includes('https://what3words.com')
-                            ? value.replace('https://what3words.com/', '///')
-                            : value;
-                        },
-                      }}
-                    >
-                      {note}
-                    </Linkify>
-                  }
-                </dd>
-              ))}
+              <PlaceNotes notes={notes} />
             </div>
           )}
         </dl>

--- a/src/pages/[postcode]/refill/places/place/place.page.tsx
+++ b/src/pages/[postcode]/refill/places/place/place.page.tsx
@@ -163,7 +163,7 @@ function RefillPlaceContent({ location }: { readonly location: Location }) {
     throw new Error(location.error);
   }
 
-  const { phoneNumber, website, openingHours, notes } =
+  const { phoneNumber, website, openingHours, note } =
     getRefillPlaceDetails(location);
   const address = cleanupAddress(location.address);
 
@@ -216,10 +216,10 @@ function RefillPlaceContent({ location }: { readonly location: Location }) {
             <dt>{t('place.details.address')}</dt>
             <dd>{address}</dd>
           </div>
-          {notes.length > 0 && (
+          {note && (
             <div>
               <dt>{t('place.details.notes')}</dt>
-              <PlaceNotes notes={notes} />
+              <PlaceNotes notes={[note]} />
             </div>
           )}
         </dl>

--- a/tests/end-to-end/refill-place.test.ts
+++ b/tests/end-to-end/refill-place.test.ts
@@ -195,7 +195,9 @@ test.describe('Refill place detail with multiple locations (first-wins logic)', 
 
     // First sub-location telephone should be shown
     const phoneLink = widget
-      .locator(`a[href="tel:${RefillLocationMultiResponse.locations[0].telephone}"]`)
+      .locator(
+        `a[href="tel:${RefillLocationMultiResponse.locations[0].telephone}"]`,
+      )
       .first();
     await expect(phoneLink).toBeVisible();
 
@@ -223,11 +225,8 @@ test.describe('Refill place detail with multiple locations (first-wins logic)', 
     await expect(websiteLink).toBeVisible();
     await expect(websiteLink).toHaveAttribute(
       'href',
-      new RegExp(
-        RefillLocationMultiResponse.locations[1].website!.replace(
-          /[.*+?^${}()|[\]\\]/g,
-          '\\$&',
-        ),
+      expect.stringContaining(
+        RefillLocationMultiResponse.locations[1].website!,
       ),
     );
 

--- a/tests/end-to-end/refill-place.test.ts
+++ b/tests/end-to-end/refill-place.test.ts
@@ -2,6 +2,7 @@ import { GEOCODE_ENDPOINT, PostcodeGeocodeResponse } from '../mocks/geocode';
 import {
   REFILL_LOCATION_ENDPOINT,
   RefillLocationResponse,
+  RefillLocationMultiResponse,
 } from '../mocks/refillLocation';
 
 import { test, expect } from './fixtures';
@@ -168,5 +169,95 @@ test.describe('Refill place detail', () => {
       'href',
       /\/EX32 7RB\/refill\/places/,
     );
+  });
+});
+
+test.describe('Refill place detail with multiple locations (first-wins logic)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route(REFILL_LOCATION_ENDPOINT, (route) => {
+      route.fulfill({ json: RefillLocationMultiResponse });
+    });
+
+    await page.route(GEOCODE_ENDPOINT, (route) => {
+      route.fulfill({ json: PostcodeGeocodeResponse });
+    });
+  });
+
+  test('Shows phone from first location that has one', async ({
+    page,
+    widget,
+  }) => {
+    await widget.evaluate((node) =>
+      node.setAttribute('path', '/EX32 7RB/refill/places/1001'),
+    );
+
+    await page.waitForRequest(REFILL_LOCATION_ENDPOINT);
+
+    // First sub-location telephone should be shown
+    const phoneLink = widget
+      .locator(`a[href="tel:${RefillLocationMultiResponse.locations[0].telephone}"]`)
+      .first();
+    await expect(phoneLink).toBeVisible();
+
+    // Third sub-location telephone should NOT appear
+    const thirdPhoneLink = widget.locator(
+      `a[href="tel:${RefillLocationMultiResponse.locations[2].telephone}"]`,
+    );
+    await expect(thirdPhoneLink).not.toBeVisible();
+  });
+
+  test('Shows website from first location that has one', async ({
+    page,
+    widget,
+  }) => {
+    await widget.evaluate((node) =>
+      node.setAttribute('path', '/EX32 7RB/refill/places/1001'),
+    );
+
+    await page.waitForRequest(REFILL_LOCATION_ENDPOINT);
+
+    // Second sub-location website should be shown (first doesn't have one)
+    const websiteLink = widget
+      .locator('a[href*="utm_source=wrap-recycling-locator"]')
+      .first();
+    await expect(websiteLink).toBeVisible();
+    await expect(websiteLink).toHaveAttribute(
+      'href',
+      new RegExp(
+        RefillLocationMultiResponse.locations[1].website!.replace(
+          /[.*+?^${}()|[\]\\]/g,
+          '\\$&',
+        ),
+      ),
+    );
+
+    // Third sub-location website should NOT appear
+    const thirdWebsiteLink = widget.locator(
+      `a[href*="${RefillLocationMultiResponse.locations[2].website}"]`,
+    );
+    await expect(thirdWebsiteLink).not.toBeVisible();
+  });
+
+  test('Shows notes from first location that has them', async ({
+    page,
+    widget,
+  }) => {
+    await widget.evaluate((node) =>
+      node.setAttribute('path', '/EX32 7RB/refill/places/1001'),
+    );
+
+    await page.waitForRequest(REFILL_LOCATION_ENDPOINT);
+
+    // Second sub-location notes should be shown (first doesn't have any)
+    const secondNotes = widget
+      .getByText(RefillLocationMultiResponse.locations[1].notes!)
+      .first();
+    await expect(secondNotes).toBeVisible();
+
+    // Third sub-location notes should NOT appear
+    const thirdNotes = widget.getByText(
+      RefillLocationMultiResponse.locations[2].notes!,
+    );
+    await expect(thirdNotes).not.toBeVisible();
   });
 });

--- a/tests/mocks/refillLocation.ts
+++ b/tests/mocks/refillLocation.ts
@@ -48,7 +48,7 @@ export const RefillLocationMultiResponse: Location = {
       locationType: 'REFILL',
       source: 'wrap',
       materials: [],
-      telephone: '01271 111111',
+      telephone: '01271111111',
       company: {
         name: 'FirstSupplier',
         refillCategories: [{ id: '1', name: 'Food' }],
@@ -69,7 +69,7 @@ export const RefillLocationMultiResponse: Location = {
       locationType: 'REFILL',
       source: 'wrap',
       materials: [],
-      telephone: '01271 999999',
+      telephone: '01271999999',
       website: 'https://www.third-location.co.uk',
       notes: 'Notes from third location',
       company: {

--- a/tests/mocks/refillLocation.ts
+++ b/tests/mocks/refillLocation.ts
@@ -29,3 +29,53 @@ export const RefillLocationResponse: Location = {
     },
   ],
 };
+
+/**
+ * Mock with multiple sub-locations to test first-wins detail logic:
+ * - First location: telephone only (no website, no notes)
+ * - Second location: website and notes (no telephone)
+ * - Third location: telephone, website, and notes (should be ignored due to first-wins)
+ */
+export const RefillLocationMultiResponse: Location = {
+  id: '1001',
+  distance: 0.5,
+  name: 'Multi Refills',
+  address: 'High Street, Barnstaple, EX31 1AA',
+  latitude: 51.0801,
+  longitude: -4.061,
+  locations: [
+    {
+      locationType: 'REFILL',
+      source: 'wrap',
+      materials: [],
+      telephone: '01271 111111',
+      company: {
+        name: 'FirstSupplier',
+        refillCategories: [{ id: '1', name: 'Food' }],
+      },
+    },
+    {
+      locationType: 'REFILL',
+      source: 'wrap',
+      materials: [],
+      website: 'https://www.second-location.co.uk',
+      notes: 'Notes from second location',
+      company: {
+        name: 'SecondSupplier',
+        refillCategories: [{ id: '2', name: 'Cleaning' }],
+      },
+    },
+    {
+      locationType: 'REFILL',
+      source: 'wrap',
+      materials: [],
+      telephone: '01271 999999',
+      website: 'https://www.third-location.co.uk',
+      notes: 'Notes from third location',
+      company: {
+        name: 'ThirdSupplier',
+        refillCategories: [{ id: '3', name: 'Beauty' }],
+      },
+    },
+  ],
+};

--- a/tests/unit/getRefillPlaceDetails.test.ts
+++ b/tests/unit/getRefillPlaceDetails.test.ts
@@ -140,9 +140,7 @@ describe('getRefillPlaceDetails', () => {
   test('What3words conversion still works in notes', () => {
     const location: Location = {
       ...baseLocation,
-      locations: [
-        makeLoc({ notes: 'Find us at ///filled.count.soap' }),
-      ],
+      locations: [makeLoc({ notes: 'Find us at ///filled.count.soap' })],
     };
     expect(getRefillPlaceDetails(location).note).toBe(
       'Find us at https://what3words.com/filled.count.soap',

--- a/tests/unit/getRefillPlaceDetails.test.ts
+++ b/tests/unit/getRefillPlaceDetails.test.ts
@@ -44,7 +44,7 @@ describe('getRefillPlaceDetails', () => {
     expect(result.phoneNumber).toBeUndefined();
     expect(result.website).toBeUndefined();
     expect(result.openingHours).toEqual({ today: '', days: [] });
-    expect(result.notes).toEqual([]);
+    expect(result.note).toBeUndefined();
   });
 
   test('returns undefined phone when no locations have a telephone', () => {
@@ -92,7 +92,7 @@ describe('getRefillPlaceDetails', () => {
         makeLoc({ notes: 'Second valid note' }),
       ],
     };
-    expect(getRefillPlaceDetails(location).notes).toEqual(['First valid note']);
+    expect(getRefillPlaceDetails(location).note).toBe('First valid note');
   });
 
   test('first-wins for opening hours: uses first sub-location that has opening hours', () => {
@@ -133,7 +133,7 @@ describe('getRefillPlaceDetails', () => {
       url: 'https://example.com',
       text: 'example.com',
     });
-    expect(result.notes).toEqual(['A helpful note']);
+    expect(result.note).toBe('A helpful note');
     expect(result.openingHours.today).toBe('10:00 - 18:00 (open now)');
   });
 
@@ -144,9 +144,9 @@ describe('getRefillPlaceDetails', () => {
         makeLoc({ notes: 'Find us at ///filled.count.soap' }),
       ],
     };
-    expect(getRefillPlaceDetails(location).notes).toEqual([
+    expect(getRefillPlaceDetails(location).note).toBe(
       'Find us at https://what3words.com/filled.count.soap',
-    ]);
+    );
   });
 
   test('skips blank/whitespace-only notes', () => {
@@ -158,7 +158,7 @@ describe('getRefillPlaceDetails', () => {
         makeLoc({ notes: 'Real note' }),
       ],
     };
-    expect(getRefillPlaceDetails(location).notes).toEqual(['Real note']);
+    expect(getRefillPlaceDetails(location).note).toBe('Real note');
   });
 
   test('returns undefined website when all locations have no website', () => {
@@ -174,7 +174,7 @@ describe('getRefillPlaceDetails', () => {
       ...baseLocation,
       locations: [makeLoc(), makeLoc()],
     };
-    expect(getRefillPlaceDetails(location).notes).toEqual([]);
+    expect(getRefillPlaceDetails(location).note).toBeUndefined();
   });
 
   test('returns empty opening hours when no sub-location has opening hours', () => {

--- a/tests/unit/getRefillPlaceDetails.test.ts
+++ b/tests/unit/getRefillPlaceDetails.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, test, vi, beforeEach, afterEach } from 'vitest';
+
+import getRefillPlaceDetails from '@/lib/details/getRefillPlaceDetails';
+import { Location } from '@/types/locatorApi';
+
+// Mock date-fns-tz to control timezone
+vi.mock('date-fns-tz', () => ({
+  toZonedTime: vi.fn((date: Date) => date),
+}));
+
+const baseLocation: Omit<Location, 'locations'> = {
+  id: '1',
+  address: 'Test Address',
+  distance: 0,
+  name: 'Test Location',
+  latitude: 0,
+  longitude: 0,
+};
+
+const makeLoc = (overrides: Partial<Location['locations'][0]> = {}) => ({
+  locationType: 'REFILL' as const,
+  source: 'wrap' as const,
+  materials: [],
+  ...overrides,
+});
+
+describe('getRefillPlaceDetails', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    // Tuesday 2024-07-09 at 10:30 AM local time
+    const baseTime = new Date('2024-07-09T00:00:00.000Z');
+    baseTime.setHours(10, 30, 0, 0);
+    vi.setSystemTime(baseTime);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test('returns undefined phone/website, empty opening hours, and empty notes when locations array is empty', () => {
+    const location: Location = { ...baseLocation, locations: [] };
+    const result = getRefillPlaceDetails(location);
+
+    expect(result.phoneNumber).toBeUndefined();
+    expect(result.website).toBeUndefined();
+    expect(result.openingHours).toEqual({ today: '', days: [] });
+    expect(result.notes).toEqual([]);
+  });
+
+  test('returns undefined phone when no locations have a telephone', () => {
+    const location: Location = {
+      ...baseLocation,
+      locations: [makeLoc(), makeLoc()],
+    };
+    expect(getRefillPlaceDetails(location).phoneNumber).toBeUndefined();
+  });
+
+  test('first-wins for phone: skips locs without phone, returns first that has one', () => {
+    const location: Location = {
+      ...baseLocation,
+      locations: [
+        makeLoc({ telephone: undefined }),
+        makeLoc({ telephone: '01234 567890' }),
+        makeLoc({ telephone: '09876 543210' }),
+      ],
+    };
+    expect(getRefillPlaceDetails(location).phoneNumber).toBe('01234567890');
+  });
+
+  test('first-wins for website: skips locs without website, returns first that has one', () => {
+    const location: Location = {
+      ...baseLocation,
+      locations: [
+        makeLoc({ website: undefined }),
+        makeLoc({ website: 'https://first.com' }),
+        makeLoc({ website: 'https://second.com' }),
+      ],
+    };
+    const result = getRefillPlaceDetails(location);
+    expect(result.website).toEqual({
+      url: 'https://first.com',
+      text: 'first.com',
+    });
+  });
+
+  test('first-wins for notes: returns only the first non-blank note', () => {
+    const location: Location = {
+      ...baseLocation,
+      locations: [
+        makeLoc({ notes: undefined }),
+        makeLoc({ notes: 'First valid note' }),
+        makeLoc({ notes: 'Second valid note' }),
+      ],
+    };
+    expect(getRefillPlaceDetails(location).notes).toEqual(['First valid note']);
+  });
+
+  test('first-wins for opening hours: uses first sub-location that has opening hours', () => {
+    const location: Location = {
+      ...baseLocation,
+      locations: [
+        makeLoc({ openingHours: undefined }),
+        makeLoc({
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          openingHours: { tuesday: { open: '09:00', close: '17:00' } } as any,
+        }),
+        makeLoc({
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          openingHours: { tuesday: { open: '08:00', close: '20:00' } } as any,
+        }),
+      ],
+    };
+    const result = getRefillPlaceDetails(location);
+    expect(result.openingHours.today).toBe('09:00 - 17:00 (open now)');
+  });
+
+  test('each detail can come from a different sub-location', () => {
+    const location: Location = {
+      ...baseLocation,
+      locations: [
+        makeLoc({ telephone: '01234 567890' }),
+        makeLoc({ website: 'https://example.com' }),
+        makeLoc({ notes: 'A helpful note' }),
+        makeLoc({
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          openingHours: { tuesday: { open: '10:00', close: '18:00' } } as any,
+        }),
+      ],
+    };
+    const result = getRefillPlaceDetails(location);
+    expect(result.phoneNumber).toBe('01234567890');
+    expect(result.website).toEqual({
+      url: 'https://example.com',
+      text: 'example.com',
+    });
+    expect(result.notes).toEqual(['A helpful note']);
+    expect(result.openingHours.today).toBe('10:00 - 18:00 (open now)');
+  });
+
+  test('What3words conversion still works in notes', () => {
+    const location: Location = {
+      ...baseLocation,
+      locations: [
+        makeLoc({ notes: 'Find us at ///filled.count.soap' }),
+      ],
+    };
+    expect(getRefillPlaceDetails(location).notes).toEqual([
+      'Find us at https://what3words.com/filled.count.soap',
+    ]);
+  });
+
+  test('skips blank/whitespace-only notes', () => {
+    const location: Location = {
+      ...baseLocation,
+      locations: [
+        makeLoc({ notes: '' }),
+        makeLoc({ notes: '   ' }),
+        makeLoc({ notes: 'Real note' }),
+      ],
+    };
+    expect(getRefillPlaceDetails(location).notes).toEqual(['Real note']);
+  });
+
+  test('returns undefined website when all locations have no website', () => {
+    const location: Location = {
+      ...baseLocation,
+      locations: [makeLoc(), makeLoc()],
+    };
+    expect(getRefillPlaceDetails(location).website).toBeUndefined();
+  });
+
+  test('returns empty notes array when no notes exist', () => {
+    const location: Location = {
+      ...baseLocation,
+      locations: [makeLoc(), makeLoc()],
+    };
+    expect(getRefillPlaceDetails(location).notes).toEqual([]);
+  });
+
+  test('returns empty opening hours when no sub-location has opening hours', () => {
+    const location: Location = {
+      ...baseLocation,
+      locations: [makeLoc(), makeLoc()],
+    };
+    expect(getRefillPlaceDetails(location).openingHours).toEqual({
+      today: '',
+      days: [],
+    });
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -32,7 +32,7 @@ export default defineConfig(({ mode }) => {
     plugins: [preact()],
 
     test: {
-      include: ['tests/unit/**/*.test.ts'],
+      include: ['tests/unit/**/*.test.{ts,tsx}'],
       environment: 'happy-dom',
       globals: true,
       coverage: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -32,7 +32,7 @@ export default defineConfig(({ mode }) => {
     plugins: [preact()],
 
     test: {
-      include: ['tests/unit/**/*.test.{ts,tsx}'],
+      include: ['tests/unit/**/*.test.ts'],
       environment: 'happy-dom',
       globals: true,
       coverage: {


### PR DESCRIPTION
The refill data comes from suppliers who stock the same store, so the store details like the website will always be the same. In the admin any of the locations within the property could contain the info we need or in the spreadsheet any one of the suppliers could have provided the info. So getRefillPlaceDetails takes the first available value for each detail type (phone, website, notes, opening hours) instead of aggregating all sub-locations.

This also extracts a PlaceNotes component to unify the what3words URL-to-display round-trip that was duplicated across two pages and simplifies getNotes regex handling with replaceAll to fix a global regex lastIndex bug. Add getRefillPlaceDetails which takes the first available value for each detail type (phone, website, notes, opening hours) instead of aggregating all sub-locations.