### PR TITLE
Fix: Prevent i18n load failures spamming Sentry as missing keys

### DIFF
--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -3,6 +3,7 @@ import HttpBackend, { HttpBackendOptions } from 'i18next-http-backend';
 import { initReactI18next } from 'react-i18next';
 
 import config from '@/config';
+import { captureException } from '@/lib/sentry';
 import { Locale } from '@/types/locale';
 
 i18n
@@ -11,6 +12,14 @@ i18n
   .use(HttpBackend)
   // pass the i18n instance to react-i18next.
   .use(initReactI18next);
+
+i18n.on('failedLoading', (lng, ns, msg) => {
+  captureException(
+    new Error(`i18n failed loading ${lng}/${ns}: ${msg}`),
+    { component: 'i18n' },
+    { lng, ns },
+  );
+});
 
 /**
  * Init i18next with the given locale.

--- a/src/lib/tArray.ts
+++ b/src/lib/tArray.ts
@@ -1,5 +1,10 @@
 import i18n from '@/lib/i18n';
-import sentry from '@/lib/sentry';
+import { captureException } from '@/lib/sentry';
+
+function translationsLoaded() {
+  const lng = i18n.resolvedLanguage ?? i18n.language;
+  return i18n.isInitialized && i18n.hasResourceBundle(lng, 'translation');
+}
 
 /**
  * Convenience method to iterate an array of translations for a given key
@@ -8,7 +13,13 @@ import sentry from '@/lib/sentry';
  */
 export default function tArray(tKey: string) {
   if (!i18n.exists(tKey)) {
-    sentry.captureMessage(`Missing translation key: ${tKey}`);
+    // Only report when bundle loaded; load failures reported via
+    // i18n `failedLoading` handler in @/lib/i18n
+    if (translationsLoaded()) {
+      captureException(new Error(`Missing translation key: ${tKey}`), {
+        component: 'tArray',
+      });
+    }
     return [];
   }
 


### PR DESCRIPTION
- [Sentry alerts for missing translation key](https://wrap.sentry.io/issues/5218105888/?alert_rule_id=15040500&alert_timestamp=1776380959074&alert_type=email&environment=production&notification_uuid=f4445d2e-0c74-4c8d-936c-e2c40527d965&project=4506864957194240&referrer=alert_email) — seem to be caused by TikTok ads for refill, as the TikTok in-app browser blocks loading.
- Currently fires once per tArray call when a translation bundle fails to load, burying the real cause under downstream symptom noise.
- Listen for i18next failedLoading and report the load failure once with lng/ns context.
- Guard tArray to only report missing keys when a bundle is actually loaded — bundle failures now flow through the new handler instead.
- Switch to captureException with Error objects for stack traces and proper Sentry grouping.