### PR TITLE
build: add reusable workflow for auto-updating package version

### DIFF
--- a/.github/workflows/check-update.yml
+++ b/.github/workflows/check-update.yml
@@ -50,16 +50,15 @@ jobs:
       - name: Read installed version
         id: pkg
         run: |
-          RANGE=$(node -p "require('./package.json').dependencies['${{ inputs.package-name }}'] || require('./package.json').devDependencies['${{ inputs.package-name }}']")
-          VERSION=$(echo "$RANGE" | sed 's/^[\^~]//')
+          VERSION=$(node -p "require('${{ inputs.package-name }}/package.json').version")
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
       - name: Open PR if there is a diff
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8.1.1
         with:
           branch: auto-update/recycling-locator-${{ steps.pkg.outputs.version }}
           base: ${{ github.ref_name }}
-          commit-message: "fix(deps): bump ${{ inputs.package-name }} to ${{ steps.pkg.outputs.version }}"
-          title: "Bump ${{ inputs.package-name }} to ${{ steps.pkg.outputs.version }}"
+          commit-message: "feat(deps): bump ${{ inputs.package-name }} to ${{ steps.pkg.outputs.version }}"
+          title: "feat(deps): bump ${{ inputs.package-name }} to ${{ steps.pkg.outputs.version }}"
           body: |
             Automated update to `${{ inputs.package-name }}` v${{ steps.pkg.outputs.version }}.
 

--- a/.github/workflows/check-update.yml
+++ b/.github/workflows/check-update.yml
@@ -13,6 +13,7 @@ on:
         required: false
         type: string
         default: ''
+permissions: {}
 jobs:
   update:
     name: Open PR to update @etchteam/recycling-locator
@@ -28,11 +29,14 @@ jobs:
       - name: Resolve node version
         id: node
         shell: bash
+        env:
+          NODE_VERSION_INPUT: ${{ inputs.node-version }}
+          WORKING_DIRECTORY_INPUT: ${{ inputs.working-directory }}
         run: |
-          if [ -n "${{ inputs.node-version }}" ]; then
-            echo "version=${{ inputs.node-version }}" >> "$GITHUB_OUTPUT"
-          elif [ -f "${{ inputs.working-directory }}/.nvmrc" ]; then
-            echo "version-file=${{ inputs.working-directory }}/.nvmrc" >> "$GITHUB_OUTPUT"
+          if [ -n "$NODE_VERSION_INPUT" ]; then
+            echo "version=$NODE_VERSION_INPUT" >> "$GITHUB_OUTPUT"
+          elif [ -f "$WORKING_DIRECTORY_INPUT/.nvmrc" ]; then
+            echo "version-file=$WORKING_DIRECTORY_INPUT/.nvmrc" >> "$GITHUB_OUTPUT"
           else
             echo "version=24" >> "$GITHUB_OUTPUT"
           fi

--- a/.github/workflows/check-update.yml
+++ b/.github/workflows/check-update.yml
@@ -45,7 +45,7 @@ jobs:
           node-version: ${{ steps.node.outputs.version }}
           node-version-file: ${{ steps.node.outputs.version-file }}
       - name: Install latest
-        run: npm install @etchteam/recycling-locator@latest
+        run: npm install --ignore-scripts @etchteam/recycling-locator@latest
       - name: Read installed version
         id: pkg
         run: |

--- a/.github/workflows/check-update.yml
+++ b/.github/workflows/check-update.yml
@@ -1,0 +1,68 @@
+---
+name: Check for package update
+on:
+  workflow_call:
+    inputs:
+      package-name:
+        description: NPM package to check
+        required: false
+        type: string
+        default: '@etchteam/recycling-locator'
+      working-directory:
+        description: Path to package.json
+        required: false
+        type: string
+        default: '.'
+      node-version:
+        description: Node version (falls back to .nvmrc then latest LTS)
+        required: false
+        type: string
+        default: ''
+jobs:
+  update:
+    name: Open PR to update @etchteam/recycling-locator
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - name: Resolve node version
+        id: node
+        shell: bash
+        run: |
+          if [ -n "${{ inputs.node-version }}" ]; then
+            echo "version=${{ inputs.node-version }}" >> "$GITHUB_OUTPUT"
+          elif [ -f "${{ inputs.working-directory }}/.nvmrc" ]; then
+            echo "version-file=${{ inputs.working-directory }}/.nvmrc" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=24" >> "$GITHUB_OUTPUT"
+          fi
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+        with:
+          node-version: ${{ steps.node.outputs.version }}
+          node-version-file: ${{ steps.node.outputs.version-file }}
+      - name: Install latest
+        run: npm install ${{ inputs.package-name }}@latest
+      - name: Read installed version
+        id: pkg
+        run: |
+          RANGE=$(node -p "require('./package.json').dependencies['${{ inputs.package-name }}'] || require('./package.json').devDependencies['${{ inputs.package-name }}']")
+          VERSION=$(echo "$RANGE" | sed 's/^[\^~]//')
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+      - name: Open PR if there is a diff
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8.1.1
+        with:
+          branch: auto-update/recycling-locator-${{ steps.pkg.outputs.version }}
+          base: ${{ github.ref_name }}
+          commit-message: "fix(deps): bump ${{ inputs.package-name }} to ${{ steps.pkg.outputs.version }}"
+          title: "Bump ${{ inputs.package-name }} to ${{ steps.pkg.outputs.version }}"
+          body: |
+            Automated update to `${{ inputs.package-name }}` v${{ steps.pkg.outputs.version }}.
+
+            Release notes: https://github.com/etchteam/recycling-locator/releases/tag/v${{ steps.pkg.outputs.version }}
+          labels: dependencies
+          delete-branch: true

--- a/.github/workflows/check-update.yml
+++ b/.github/workflows/check-update.yml
@@ -3,11 +3,6 @@ name: Check for package update
 on:
   workflow_call:
     inputs:
-      package-name:
-        description: NPM package to check
-        required: false
-        type: string
-        default: '@etchteam/recycling-locator'
       working-directory:
         description: Path to package.json
         required: false
@@ -46,21 +41,21 @@ jobs:
           node-version: ${{ steps.node.outputs.version }}
           node-version-file: ${{ steps.node.outputs.version-file }}
       - name: Install latest
-        run: npm install ${{ inputs.package-name }}@latest
+        run: npm install @etchteam/recycling-locator@latest
       - name: Read installed version
         id: pkg
         run: |
-          VERSION=$(node -p "require('${{ inputs.package-name }}/package.json').version")
+          VERSION=$(node -p "require('@etchteam/recycling-locator/package.json').version")
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
       - name: Open PR if there is a diff
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8.1.1
         with:
           branch: auto-update/recycling-locator-${{ steps.pkg.outputs.version }}
           base: ${{ github.ref_name }}
-          commit-message: "feat(deps): bump ${{ inputs.package-name }} to ${{ steps.pkg.outputs.version }}"
-          title: "feat(deps): bump ${{ inputs.package-name }} to ${{ steps.pkg.outputs.version }}"
+          commit-message: "feat(deps): bump @etchteam/recycling-locator to ${{ steps.pkg.outputs.version }}"
+          title: "feat(deps): bump @etchteam/recycling-locator to ${{ steps.pkg.outputs.version }}"
           body: |
-            Automated update to `${{ inputs.package-name }}` v${{ steps.pkg.outputs.version }}.
+            Automated update to `@etchteam/recycling-locator` v${{ steps.pkg.outputs.version }}.
 
             Release notes: https://github.com/etchteam/recycling-locator/releases/tag/v${{ steps.pkg.outputs.version }}
           labels: dependencies

--- a/readme.md
+++ b/readme.md
@@ -48,7 +48,7 @@ Include the stylesheet within your website styles (optional)
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@etchteam/recycling-locator@latest/dist/recycling-locator.css">
 ```
 
-⚠️ Dependabot is configured to notify daily for NPM version changes, falling out of date means the widget could stop working due to upstream breaking API changes.
+⚠️ Falling out of date means the widget could stop working due to upstream breaking API changes. See [Keeping up to date (NPM installs)](#keeping-up-to-date-npm-installs) for the recommended auto-update workflow.
 
 ## Available settings
 
@@ -950,6 +950,46 @@ document
     console.info('Ready to recycle');
   });
 ```
+
+## Keeping up to date (NPM installs)
+
+If you install this package via NPM (rather than loading the prebuilt
+widget from a CDN), you should keep it up to date — it calls live APIs
+and ships fixes frequently.
+
+To auto-update, add this workflow to your repo at
+`.github/workflows/recycling-locator-update.yml`:
+
+```yaml
+name: Update recycling-locator
+on:
+  schedule:
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+jobs:
+  update:
+    uses: etchteam/recycling-locator/.github/workflows/check-update.yml@v1
+    permissions:
+      contents: write
+      pull-requests: write
+```
+
+Daily at 06:00 UTC the workflow checks npm for a new version and opens a
+PR if found. Manually trigger via the Actions tab → "Update
+recycling-locator" → "Run workflow".
+
+### Options
+
+| Input | Default | Purpose |
+|---|---|---|
+| `working-directory` | `.` | Path to your `package.json` |
+| `node-version` | `.nvmrc` then latest LTS | Node version |
+
+### Auto-merging
+
+PR author is `github-actions[bot]`. If you use mergify or branch
+auto-merge rules, ensure they cover this author for PRs labelled
+`dependencies`.
 
 ## Contributing
 


### PR DESCRIPTION
## Summary

Adds a reusable GitHub Actions workflow plus README docs so consumers of `@etchteam/recycling-locator` can auto-update via a single caller workflow.

- `.github/workflows/check-update.yml` — reusable workflow (`on: workflow_call`) that installs the latest version and opens a PR in the caller repo if there is drift.
- `readme.md` — new "Keeping up to date (NPM installs)" section showing consumers how to adopt it; outdated dependabot note replaced with a pointer to the new section.

The `v1` tag will be created on `main` after this PR merges so consumers can pin via `@v1`.

## Notes

- All third-party actions are pinned to commit SHAs with `# vX.Y.Z` trailing comments.
- Commit message uses `build:` prefix so semantic-release does not trigger a release on workflow-only changes.
- The PR opened by the workflow uses `feat(deps): …` so consumers running semantic-release get release on merge
- YAML validated with `yaml-lint`.