### PR TITLE
build: add top-level empty permissions to caller workflow example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -966,6 +966,7 @@ on:
   schedule:
     - cron: '0 6 * * *'
   workflow_dispatch:
+permissions: {}
 jobs:
   update:
     uses: etchteam/recycling-locator/.github/workflows/check-update.yml@v1


### PR DESCRIPTION
Adds `permissions: {}` at the top level of the example caller workflow in the README so consumers who copy-paste don't hit Checkov CKV2_GHA_1 (write-all default).