### PR TITLE
fix: support supplierless stores

### DIFF
--- a/src/components/content/RefillBrands/RefillBrands.tsx
+++ b/src/components/content/RefillBrands/RefillBrands.tsx
@@ -1,4 +1,5 @@
 import camelCase from 'lodash/camelCase';
+import { useTranslation } from 'react-i18next';
 
 import { useAppState } from '@/hooks/AppStateProvider';
 import { CustomElement } from '@/types/customElement';
@@ -14,8 +15,17 @@ export default function RefillBrands({
   companyNames,
   title,
 }: RefillBrandsProps) {
+  const { i18n } = useTranslation();
   const { publicPath } = useAppState();
   if (companyNames.length === 0) {
+    return null;
+  }
+
+  const filteredBrands = companyNames.filter((name) => {
+    return i18n.exists(`refill.place.suppliers.${camelCase(name)}.name`);
+  });
+
+  if (!filteredBrands.length) {
     return null;
   }
 
@@ -26,7 +36,7 @@ export default function RefillBrands({
           <div className="refill-brands-content">
             <h3>{title}</h3>
             <ul className="list-style-none refill-brands-list">
-              {companyNames.map((name) => (
+              {filteredBrands.map((name) => (
                 <li key={name}>
                   <img
                     src={`${publicPath}images/refill/logos/${camelCase(name)}.webp`}

--- a/src/pages/[postcode]/refill/places/place/place.page.tsx
+++ b/src/pages/[postcode]/refill/places/place/place.page.tsx
@@ -154,7 +154,7 @@ function RefillCompanyContent({ location }: { readonly location: Location }) {
           );
         }
 
-        return null
+        return null;
       })}
     </>
   );

--- a/src/pages/[postcode]/refill/places/place/place.page.tsx
+++ b/src/pages/[postcode]/refill/places/place/place.page.tsx
@@ -75,7 +75,7 @@ function RefillProductsContent({
 }
 
 function RefillCompanyContent({ location }: { readonly location: Location }) {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const { publicPath } = useAppState();
 
   const companies = getCompanyNames(location).map((name) => camelCase(name));
@@ -114,43 +114,47 @@ function RefillCompanyContent({ location }: { readonly location: Location }) {
           );
         }
 
-        return (
-          <div key={company} className="evg-spacing-top-md">
-            <p className="evg-text-weight-bold evg-font-size-sm evg-spacing-bottom-md">
-              {t('refill.place.supplied', { place: location.name })}
-            </p>
-            <evg-row>
-              <evg-img radius="sm">
-                <img
-                  src={`${publicPath}images/refill/logos/${company}.webp`}
-                  alt={t(`refill.place.suppliers.${company}.name`) + ' logo'}
-                  width="48"
-                  height="48"
-                />
-              </evg-img>
-              <div>
-                <p className="evg-text-weight-bold evg-spacing-bottom-none">
-                  {t(`refill.place.suppliers.${company}.name`)}
-                </p>
-                <evg-chip variant="light">
-                  <a
-                    href={t(`refill.place.suppliers.${company}.url`)}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    <locator-icon
-                      icon="web-link"
-                      className="evg-spacing-right-xs"
-                    />
-                    {t(`refill.place.suppliers.${company}.urlText`)}
-                  </a>
-                </evg-chip>
-              </div>
-            </evg-row>
-            <p>{t(`refill.place.suppliers.${company}.description`)}</p>
-            <hr />
-          </div>
-        );
+        if (i18n.exists(`refill.place.suppliers.${company}.name`)) {
+          return (
+            <div key={company} className="evg-spacing-top-md">
+              <p className="evg-text-weight-bold evg-font-size-sm evg-spacing-bottom-md">
+                {t('refill.place.supplied', { place: location.name })}
+              </p>
+              <evg-row>
+                <evg-img radius="sm">
+                  <img
+                    src={`${publicPath}images/refill/logos/${company}.webp`}
+                    alt={t(`refill.place.suppliers.${company}.name`) + ' logo'}
+                    width="48"
+                    height="48"
+                  />
+                </evg-img>
+                <div>
+                  <p className="evg-text-weight-bold evg-spacing-bottom-none">
+                    {t(`refill.place.suppliers.${company}.name`)}
+                  </p>
+                  <evg-chip variant="light">
+                    <a
+                      href={t(`refill.place.suppliers.${company}.url`)}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      <locator-icon
+                        icon="web-link"
+                        className="evg-spacing-right-xs"
+                      />
+                      {t(`refill.place.suppliers.${company}.urlText`)}
+                    </a>
+                  </evg-chip>
+                </div>
+              </evg-row>
+              <p>{t(`refill.place.suppliers.${company}.description`)}</p>
+              <hr />
+            </div>
+          );
+        }
+
+        return null
       })}
     </>
   );

--- a/tests/end-to-end/refill-place.test.ts
+++ b/tests/end-to-end/refill-place.test.ts
@@ -3,6 +3,7 @@ import {
   REFILL_LOCATION_ENDPOINT,
   RefillLocationResponse,
   RefillLocationMultiResponse,
+  RefillLocationUnknownSupplierResponse,
 } from '../mocks/refillLocation';
 
 import { test, expect } from './fixtures';
@@ -135,6 +136,31 @@ test.describe('Refill place detail', () => {
     await expect(websiteLink).toHaveAttribute('rel', /noopener noreferrer/);
   });
 
+  test('Shows supplier details block for a known supplier', async ({
+    page,
+    widget,
+    i18n,
+  }) => {
+    await widget.evaluate((node) =>
+      node.setAttribute('path', '/EX32 7RB/refill/places/1001'),
+    );
+
+    await page.waitForRequest(REFILL_LOCATION_ENDPOINT);
+
+    // RefillLocationResponse's company is "Ecover", a known supplier
+    const suppliedHeading = widget
+      .getByText(
+        i18n.t('refill.place.supplied', { place: RefillLocationResponse.name }),
+      )
+      .first();
+    await expect(suppliedHeading).toBeVisible();
+
+    const supplierName = widget
+      .getByText(i18n.t('refill.place.suppliers.ecover.name'))
+      .first();
+    await expect(supplierName).toBeVisible();
+  });
+
   test('Supplier website chip links open in new tab', async ({
     page,
     widget,
@@ -258,5 +284,47 @@ test.describe('Refill place detail with multiple locations (first-wins logic)', 
       RefillLocationMultiResponse.locations[2].notes!,
     );
     await expect(thirdNotes).not.toBeVisible();
+  });
+});
+
+test.describe('Refill place detail with an unknown supplier', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route(REFILL_LOCATION_ENDPOINT, (route) => {
+      route.fulfill({ json: RefillLocationUnknownSupplierResponse });
+    });
+
+    await page.route(GEOCODE_ENDPOINT, (route) => {
+      route.fulfill({ json: PostcodeGeocodeResponse });
+    });
+  });
+
+  test('Omits the supplier details block when the company is not a known supplier', async ({
+    page,
+    widget,
+    i18n,
+  }) => {
+    await widget.evaluate((node) =>
+      node.setAttribute('path', '/EX32 7RB/refill/places/1001'),
+    );
+
+    await page.waitForRequest(REFILL_LOCATION_ENDPOINT);
+
+    // Page still renders (location name is shown)
+    const placeName = widget
+      .getByText(RefillLocationUnknownSupplierResponse.name)
+      .first();
+    await expect(placeName).toBeVisible();
+
+    // The "supplied by" heading must not appear for an unknown supplier
+    const suppliedHeading = widget.getByText(
+      i18n.t('refill.place.supplied', {
+        place: RefillLocationUnknownSupplierResponse.name,
+      }),
+    );
+    await expect(suppliedHeading).not.toBeVisible();
+
+    // No raw, untranslated supplier keys should leak into the DOM
+    const rawKey = widget.getByText(/refill\.place\.suppliers\./);
+    await expect(rawKey).not.toBeVisible();
   });
 });

--- a/tests/end-to-end/refill-places.test.ts
+++ b/tests/end-to-end/refill-places.test.ts
@@ -4,6 +4,8 @@ import {
   RefillLocationsFilteredResponse,
   RefillLocationsEmptyResponse,
   RefillLocationsWithBrandsResponse,
+  RefillLocationsWithUnknownBrandResponse,
+  RefillLocationsAllUnknownBrandsResponse,
 } from '../mocks/refillLocations';
 
 import { test, expect } from './fixtures';
@@ -265,6 +267,61 @@ test.describe('Refill places', () => {
     const faithInNature = brandsCard.getByAltText('Faith in Nature');
     await expect(ecover).toBeVisible();
     await expect(faithInNature).toBeVisible();
+  });
+
+  test('Only known brand logos render, unknown brands are filtered out', async ({
+    page,
+    widget,
+  }) => {
+    await page.route(REFILL_LOCATIONS_ENDPOINT, (route) => {
+      route.fulfill({ json: RefillLocationsWithUnknownBrandResponse });
+    });
+
+    await widget.evaluate((node) =>
+      node.setAttribute('path', '/EX32 7RB/refill/places'),
+    );
+
+    await page.waitForRequest(REFILL_LOCATIONS_ENDPOINT);
+
+    const brandsCard = widget.locator('locator-refill-brands').first();
+    await expect(brandsCard).toBeVisible();
+
+    // Known supplier renders
+    await expect(brandsCard.getByAltText('Ecover')).toBeVisible();
+
+    // Company without a suppliers translation is filtered out of the DOM
+    // (toHaveCount, not visibility: a broken <img> would also be "not visible")
+    await expect(brandsCard.getByAltText('Independent Refill Co')).toHaveCount(
+      0,
+    );
+    await expect(brandsCard.locator('li')).toHaveCount(1);
+  });
+
+  test('Brands card is hidden when no companies are known brands', async ({
+    page,
+    widget,
+  }) => {
+    await page.route(REFILL_LOCATIONS_ENDPOINT, (route) => {
+      route.fulfill({ json: RefillLocationsAllUnknownBrandsResponse });
+    });
+
+    await widget.evaluate((node) =>
+      node.setAttribute('path', '/EX32 7RB/refill/places'),
+    );
+
+    await page.waitForRequest(REFILL_LOCATIONS_ENDPOINT);
+
+    // Wait for results to render first; RefillBrands renders in the same block
+    // as the places grid, so once the grid is present the brands card has had
+    // its chance to render (or return null). Without this barrier the absence
+    // assertion below would pass trivially against the not-yet-rendered page.
+    await expect(
+      widget.locator('locator-places-grid li').first(),
+    ).toBeVisible();
+
+    // All companies lack a suppliers translation, so the component returns null
+    // and the element is absent from the DOM.
+    await expect(widget.locator('locator-refill-brands')).toHaveCount(0);
   });
 
   test('Category filter is hidden when no refill places exist', async ({

--- a/tests/mocks/refillLocation.ts
+++ b/tests/mocks/refillLocation.ts
@@ -31,6 +31,38 @@ export const RefillLocationResponse: Location = {
 };
 
 /**
+ * Mock whose company is NOT one of the known refill suppliers (no entry under
+ * `refill.place.suppliers`). Used to verify the supplier details block is
+ * omitted rather than rendering broken translation keys / images.
+ */
+export const RefillLocationUnknownSupplierResponse: Location = {
+  id: '1001',
+  distance: 0.5,
+  name: 'Independent Refills',
+  address: 'High Street, Barnstaple, EX31 1AA',
+  latitude: 51.0801,
+  longitude: -4.061,
+  locations: [
+    {
+      locationType: 'REFILL',
+      source: 'wrap',
+      materials: [],
+      telephone: '01271 374776',
+      website: 'https://www.independentrefills.co.uk',
+      openingHours:
+        'Monday: 09:00 - 17:00, Tuesday: 09:00 - 17:00, Wednesday: 09:00 - 17:00',
+      company: {
+        name: 'Independent Refill Co',
+        refillCategories: [
+          { id: '1', name: 'Food' },
+          { id: '2', name: 'Cleaning' },
+        ],
+      },
+    },
+  ],
+};
+
+/**
  * Mock with multiple sub-locations to test first-wins detail logic:
  * - First location: telephone only (no website, no notes)
  * - Second location: website and notes (no telephone)

--- a/tests/mocks/refillLocations.ts
+++ b/tests/mocks/refillLocations.ts
@@ -142,6 +142,90 @@ export const RefillLocationsWithBrandsResponse: LocationsResponseType = {
   },
 };
 
+/**
+ * Mix of a known supplier (Ecover) and a company with no entry under
+ * `refill.place.suppliers`. Only the known brand's logo should render.
+ */
+export const RefillLocationsWithUnknownBrandResponse: LocationsResponseType = {
+  items: [
+    {
+      ...RefillLocationsResponse.items[0],
+      locations: [
+        {
+          locationType: 'REFILL',
+          source: 'wrap',
+          materials: [],
+          company: {
+            name: 'Ecover',
+            refillCategories: [{ id: '2', name: 'Cleaning' }],
+          },
+        },
+      ],
+    },
+    {
+      ...RefillLocationsResponse.items[1],
+      locations: [
+        {
+          locationType: 'REFILL',
+          source: 'wrap',
+          materials: [],
+          company: {
+            name: 'Independent Refill Co',
+            refillCategories: [{ id: '3', name: 'Personal Care' }],
+          },
+        },
+      ],
+    },
+  ],
+  meta: RefillLocationsResponse.meta,
+  pagination: {
+    total: 2,
+    page: 1,
+  },
+};
+
+/**
+ * Only companies that have no entry under `refill.place.suppliers`. The brands
+ * card should not render at all.
+ */
+export const RefillLocationsAllUnknownBrandsResponse: LocationsResponseType = {
+  items: [
+    {
+      ...RefillLocationsResponse.items[0],
+      locations: [
+        {
+          locationType: 'REFILL',
+          source: 'wrap',
+          materials: [],
+          company: {
+            name: 'Independent Refill Co',
+            refillCategories: [{ id: '2', name: 'Cleaning' }],
+          },
+        },
+      ],
+    },
+    {
+      ...RefillLocationsResponse.items[1],
+      locations: [
+        {
+          locationType: 'REFILL',
+          source: 'wrap',
+          materials: [],
+          company: {
+            name: 'Another Unknown Shop',
+            refillCategories: [{ id: '3', name: 'Personal Care' }],
+          },
+        },
+      ],
+    },
+  ],
+  meta: RefillLocationsResponse.meta,
+  pagination: {
+    total: 2,
+    page: 1,
+  },
+};
+
 export const RefillLocationsEmptyResponse: LocationsResponseType = {
   items: [],
   meta: RefillLocationsResponse.meta,


### PR DESCRIPTION
Hides the supplier info for independent supplierless stores so we only display the store info.

Tested by adding a store with no supplier.